### PR TITLE
add the kernel switching tool

### DIFF
--- a/kernel-switcher/README.md
+++ b/kernel-switcher/README.md
@@ -16,9 +16,18 @@ as the argument. Examples:
 - `switch_kernel.py 6.2.0-33-generic`
 - `switch_kernel.py realtime`
 
-Note how the argument is fuzzy matched. But beware, first match will be used
-so for instance if `realtime` is used as the argument, first grub's menuentry
+The matching is done by looking for the string provided as argument in the
+GRUB's menuentries. AKA `argument in menuentry`. No regex matching is done.
+
+Note that the GRUB's menuentry that will be chosen is the first one that
+contains the given argument.
+
+For instance if `realtime` is used as the argument, first grub's menuentry
 that matches `realtime` will be used.
+
+If you wish to use a precise kernel string, like
+`gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-f565c524c2a6`
+you are free to do so.
 
 ## Testing
 

--- a/kernel-switcher/README.md
+++ b/kernel-switcher/README.md
@@ -1,0 +1,26 @@
+# Ubuntu Kernel Switcher
+
+## Summary
+
+Ubuntu Kernel Switcher is a utility that lets you switch to a specific
+kernel. Notably, post-switch, that kernel becomes the default, ensuring
+it remains after system updates introduce new kernels.
+
+## Usage
+
+To run the tool, use invoke `switch_kernel.py` with the desired kernel
+as the argument. Examples:
+
+- `switch_kernel.py 6.5`
+- `switch_kernel.py generic`
+- `switch_kernel.py 6.2.0-33-generic`
+- `switch_kernel.py realtime`
+
+Note how the argument is fuzzy matched. But beware, first match will be used
+so for instance if `realtime` is used as the argument, first grub's menuentry
+that matches `realtime` will be used.
+
+## Testing
+
+There `test_in_lxd_vm.py` is a script that tests the tool inside LXD's VMs.
+(So it's somewhat safe to be used).

--- a/kernel-switcher/switch_kernel.py
+++ b/kernel-switcher/switch_kernel.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 This program selects the kernel to boot into.
@@ -19,49 +32,31 @@ def get_submenu_entry(grub_cfg_contents: str):
     :param grub_cfg_contents: the contents of /boot/grub/grub.cfg
     :return: the identifier of the "advanced" submenu entry
     :raises SystemExit: if the identifier could not be found
-
-    >>> grub_entry = (
-    ... "submenu 'Advanced options for Ubuntu' $menuentry_id_option "
-    ... "'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6' {"
-    ... )
-    >>> get_submenu_entry(grub_entry)
-    'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6'
-    >>> get_submenu_entry('foo')
-    Traceback (most recent call last):
-        ...
-    SystemExit: Could not find submenu entry in grub.cfg
     """
 
     for line in grub_cfg_contents.splitlines():
-        if "submenu" in line:
+        if "submenu" in line and "Advanced" in line:
             identifier = line.split()[6]
             return identifier.replace("'", "")
     raise SystemExit("Could not find submenu entry in grub.cfg")
 
 
+def assert_root():
+    """
+    Do nothing if the user is root, otherwise exit the program wit han error.
+    """
+    if os.geteuid() != 0:
+        raise SystemExit("This program must be run as root.")
+
+
 def find_menuentry_for_kernel(keyword: str, grub_cfg_contents: str):
     """
     Returns the menuentry for the kernel that matches the keyword.
+
     :param keyword: the keyword to search for
     :param grub_cfg_contents: the contents of /boot/grub/grub.cfg
     :return: the menuentry for the kernel that matches the keyword
     :raises SystemExit: if the adequate menuentry could not be found
-    >>> grub_entry = (
-    ... "menuentry 'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
-    ... "--class gnu-linux --class gnu --class os $menuentry_id_option "
-    ... "'gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-"
-    ... "f565c524c2a6' {"
-    ... )
-    >>> correct_match = ('gnulinux-5.4.0-80-generic-advanced-'
-    ... 'aca31037-7571-415c-b666-f565c524c2a6')
-    >>> match = find_menuentry_for_kernel('5.4.0-80', grub_entry)
-    >>> match == correct_match
-    True
-    >>> find_menuentry_for_kernel('5.4.0-80', 'foo')
-    Traceback (most recent call last):
-        ...
-    SystemExit: Could not find kernel in grub.cfg
-
     """
 
     for line in grub_cfg_contents.splitlines():
@@ -73,7 +68,62 @@ def find_menuentry_for_kernel(keyword: str, grub_cfg_contents: str):
     raise SystemExit("Could not find kernel in grub.cfg")
 
 
-def main(argv):
+def get_grub_cfg_contents():
+    """
+    Returns the contents of /boot/grub/grub.cfg.
+
+    :return: the contents of /boot/grub/grub.cfg
+    :raises SystemExit: if the file could not be read
+    """
+
+    try:
+        with open("/boot/grub/grub.cfg", "rt") as grub_cfg:
+            return grub_cfg.read()
+    except OSError as e:
+        raise SystemExit(f"Could not read /boot/grub/grub.cfg: {e}")
+
+
+def get_grub_default_contents():
+    """
+    Returns the contents of /etc/default/grub.
+
+    :return: the contents of /etc/default/grub
+    :raises SystemExit: if the file could not be read
+    """
+
+    try:
+        with open("/etc/default/grub", "rt") as grub_default:
+            return grub_default.read()
+    except OSError as e:
+        raise SystemExit(f"Could not read /etc/default/grub: {e}")
+
+
+def update_grub_default_contents(new_grub_default_contents):
+    """
+    Writes the contents of /etc/default/grub and applies the changes.
+
+    :return: the contents of /etc/default/grub
+    :raises SystemExit: if the file could not be read
+    """
+
+    try:
+        with open("/etc/default/grub", "wt") as grub_default:
+            grub_default.write(new_grub_default_contents)
+    except OSError as e:
+        raise SystemExit(f"Could not write /etc/default/grub: {e}")
+    print("Updating grub...")
+    subprocess.run(["update-grub"])
+    print("Done.")
+
+
+def parse_args(argv):
+    """
+    Parse the command line arguments.
+
+    :param argv: the command line arguments
+    :return: a pair with the important arguments
+    """
+
     parser = argparse.ArgumentParser(
         description="Select the kernel to boot into."
     )
@@ -84,11 +134,21 @@ def main(argv):
         nargs=1,
         help="the kernel to boot into",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="do not write anything to the grub config",
+    )
+
     args = parser.parse_args(argv[1:])
-    kernel = args.kernel[0]
+    return args.kernel[0], args.dry_run
+
+
+def main(argv):
+    kernel, dry_run = parse_args(argv)
+
     print("Reading existing kernel from /boot/grub/grub.cfg...")
-    with open("/boot/grub/grub.cfg", "rt") as grub_cfg:
-        grub_cfg_contents = grub_cfg.read()
+    grub_cfg_contents = get_grub_cfg_contents()
     submenu_entry = get_submenu_entry(grub_cfg_contents)
     print(f"Found submenu entry: {submenu_entry}")
 
@@ -100,24 +160,29 @@ def main(argv):
     # otherwise the kernel will not boot
     print("Removing 'force partuuid' from grub config...")
     file_path = "/etc/default/grub.d/40-force-partuuid.cfg"
-    if os.path.exists(file_path):
+    if dry_run:
+        print("Dry run, not removing the partuuid.cfg file.")
+    elif os.path.exists(file_path):
         os.remove(file_path)
+    else:
+        print("partuuid.cfg not found, not removing.")
 
     new_default = f"{submenu_entry}>{menuentry}"
     print(f"Setting new default: {new_default}")
-    with open("/etc/default/grub", "rt") as grub_default:
-        grub_default_contents = grub_default.read()
+
+    grub_default_contents = get_grub_default_contents()
     new_grub_default_contents = re.sub(
         r"GRUB_DEFAULT=.*",
         f"GRUB_DEFAULT='{new_default}'",
         grub_default_contents,
     )
-    with open("/etc/default/grub", "wt") as grub_default:
-        grub_default.write(new_grub_default_contents)
-    print("Updating grub...")
-    subprocess.run(["update-grub"])
-    print("Done.")
+    if dry_run:
+        print("Dry run, not writing to grub config.")
+        print("Would have written:")
+        print(new_grub_default_contents)
+        return
+    update_grub_default_contents(new_grub_default_contents)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main(sys.argv)

--- a/kernel-switcher/switch_kernel.py
+++ b/kernel-switcher/switch_kernel.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+"""
+This program selects the kernel to boot into.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def get_submenu_entry(grub_cfg_contents: str):
+    """
+    Returns the identifier of the "advanced" submenu entry from the contents
+    of /boot/grub/grub.cfg.
+
+    :param grub_cfg_contents: the contents of /boot/grub/grub.cfg
+    :return: the identifier of the "advanced" submenu entry
+    :raises SystemExit: if the identifier could not be found
+
+    >>> grub_entry = (
+    ... "submenu 'Advanced options for Ubuntu' $menuentry_id_option "
+    ... "'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6' {"
+    ... )
+    >>> get_submenu_entry(grub_entry)
+    'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6'
+    >>> get_submenu_entry('foo')
+    Traceback (most recent call last):
+        ...
+    SystemExit: Could not find submenu entry in grub.cfg
+    """
+
+    for line in grub_cfg_contents.splitlines():
+        if "submenu" in line:
+            identifier = line.split()[6]
+            return identifier.replace("'", "")
+    raise SystemExit("Could not find submenu entry in grub.cfg")
+
+
+def find_menuentry_for_kernel(keyword: str, grub_cfg_contents: str):
+    """
+    Returns the menuentry for the kernel that matches the keyword.
+    :param keyword: the keyword to search for
+    :param grub_cfg_contents: the contents of /boot/grub/grub.cfg
+    :return: the menuentry for the kernel that matches the keyword
+    :raises SystemExit: if the adequate menuentry could not be found
+    >>> grub_entry = (
+    ... "menuentry 'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
+    ... "--class gnu-linux --class gnu --class os $menuentry_id_option "
+    ... "'gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-"
+    ... "f565c524c2a6' {"
+    ... )
+    >>> correct_match = ('gnulinux-5.4.0-80-generic-advanced-'
+    ... 'aca31037-7571-415c-b666-f565c524c2a6')
+    >>> match = find_menuentry_for_kernel('5.4.0-80', grub_entry)
+    >>> match == correct_match
+    True
+    >>> find_menuentry_for_kernel('5.4.0-80', 'foo')
+    Traceback (most recent call last):
+        ...
+    SystemExit: Could not find kernel in grub.cfg
+
+    """
+
+    for line in grub_cfg_contents.splitlines():
+        if "menuentry" in line and keyword in line and "recovery" not in line:
+            # Searching for the pattern using a regular expression
+            match = re.search(r"\w*gnulinux.*\w", line)
+            if match:
+                return match.group()
+    raise SystemExit("Could not find kernel in grub.cfg")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Select the kernel to boot into."
+    )
+    parser.add_argument(
+        "kernel",
+        metavar="KERNEL",
+        type=str,
+        nargs=1,
+        help="the kernel to boot into",
+    )
+    args = parser.parse_args(argv[1:])
+    kernel = args.kernel[0]
+    print("Reading existing kernel from /boot/grub/grub.cfg...")
+    with open("/boot/grub/grub.cfg", "rt") as grub_cfg:
+        grub_cfg_contents = grub_cfg.read()
+    submenu_entry = get_submenu_entry(grub_cfg_contents)
+    print(f"Found submenu entry: {submenu_entry}")
+
+    print(f"Searching for menuentry for kernel {kernel}...")
+    menuentry = find_menuentry_for_kernel(kernel, grub_cfg_contents)
+    print(f"Found menuentry: {menuentry}")
+
+    # let's remove the "force partuuid" file from the grub config
+    # otherwise the kernel will not boot
+    print("Removing 'force partuuid' from grub config...")
+    file_path = "/etc/default/grub.d/40-force-partuuid.cfg"
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    new_default = f"{submenu_entry}>{menuentry}"
+    print(f"Setting new default: {new_default}")
+    with open("/etc/default/grub", "rt") as grub_default:
+        grub_default_contents = grub_default.read()
+    new_grub_default_contents = re.sub(
+        r"GRUB_DEFAULT=.*",
+        f"GRUB_DEFAULT='{new_default}'",
+        grub_default_contents,
+    )
+    with open("/etc/default/grub", "wt") as grub_default:
+        grub_default.write(new_grub_default_contents)
+    print("Updating grub...")
+    subprocess.run(["update-grub"])
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/kernel-switcher/test_in_lxd_vm.py
+++ b/kernel-switcher/test_in_lxd_vm.py
@@ -1,0 +1,155 @@
+#!usr/bin/env python3
+"""
+This is a test script for the kernel switcher.
+It uses LXD to create a VM in which the test script runs this sequence:
+- install a kernel that's older than the default
+- reboot
+- check that the old kernel is _still not_ running
+- use the kernel switch tool to switch to the old kernel
+- reboot
+- check that the older kernel is running
+"""
+import subprocess
+import shlex
+import time
+import contextlib
+import signal
+
+
+class InterruptHandler:
+    def __init__(self):
+        self.interrupted = False
+        self.first_interrupt_time = time.time()
+        signal.signal(signal.SIGINT, self.signal_handler)
+
+    def signal_handler(self, signum, frame):
+        if self.interrupted and time.time() > self.first_interrupt_time + 2:
+            print("\nForced exit.You'll have to do the cleanup yourself.")
+            raise KeyboardInterrupt
+        self.interrupted = True
+        print(
+            "\nCTRL+C detected while using a VM...\n"
+            "Press CTRL+C again in 2 seconds if you really want to force exit"
+        )
+
+
+interrupt_handler = InterruptHandler()
+
+
+class VMContext:
+    def __init__(self, vm_name):
+        self.vm_name = vm_name
+
+    def __enter__(self):
+        print(f"Creating '{self.vm_name}' VM...")
+
+        self._run_host_command(
+            f"lxc launch ubuntu:22.04 {self.vm_name} --vm -c security.secureboot=false"
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        print(f"Deleting '{self.vm_name}' VM...")
+        self._run_host_command(f"lxc delete --force {self.vm_name}")
+
+    def _run_host_command(self, cmd, supress=False):
+        """Executes a command on the host and returns the output."""
+        try:
+            cmd_list = shlex.split(cmd)
+            result = subprocess.run(
+                cmd_list,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            return result.stdout
+        except subprocess.CalledProcessError as exc:
+            if not supress:
+                print(f"Error while running command: {cmd}")
+                print(f"Error message: {exc.output}")
+            raise
+
+    def run_vm_command(self, cmd, supress=False):
+        """Executes a command inside the VM and returns the output."""
+        print(f"Running command inside VM: {cmd}")
+        full_cmd = f"lxc exec {self.vm_name} -- {cmd}"
+        return self._run_host_command(full_cmd, supress)
+
+    def wait_for_vm_ready(self, timeout=60):
+        """Waits until the VM is responsive."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                self.run_vm_command("true", supress=True)
+                return
+            except subprocess.CalledProcessError:
+                time.sleep(1)
+        raise TimeoutError(
+            f"VM '{self.vm_name}' did not become ready within {timeout} seconds."
+        )
+
+
+def extract_kernel_pkgs_from_apt_log(apt_log):
+    """
+    Returns the name of the kernel package from the apt log.
+
+    >>> text = '''
+    ... linux-image-5.4.0-80-generic/focal-updates,rubbish [more rubbish]]]
+    ... linux-image-5.4.0-81-generic/focal-updates, no rubbish
+    ... at all!
+    ... well almost, okay, one more linux-image like incoming
+    ... linux-image-5.15.0-1041-kvm/jammy-updates 5.15.0-1041.46 amd64'''
+    >>> extract_kernel_pkgs_from_apt_log(text) == [
+    ...     'linux-image-5.4.0-80-generic',
+    ...     'linux-image-5.4.0-81-generic',
+    ...     'linux-image-5.15.0-1041-kvm']
+    True
+    """
+    # list comprehension here would be unreadable due to line length
+    # let's do this imperatively
+    # not using a regex because even here it may be easier to understand
+    # with just python's string methods
+    extraceted_pkgs = []
+
+    for line in apt_log.splitlines():
+        if line.startswith("linux-image"):
+            extraceted_pkgs.append(line.split("/")[0])
+    return extraceted_pkgs
+
+
+def main():
+    interrupt_handler = InterruptHandler()
+    with VMContext("vm-test") as vm:
+        # Wait for VM to be ready
+        time.sleep(10)
+        vm.wait_for_vm_ready()
+        original_kernel = vm.run_vm_command("uname -r")
+        print(f"Original kernel: {original_kernel}")
+        vm.run_vm_command("apt update")
+        pkgs = extract_kernel_pkgs_from_apt_log(
+            vm.run_vm_command("apt search 'linux-image.*-kvm'")
+        )
+        # the first entry in pkgs should be the oldest version of a kvm kernel
+        # let's install it
+        print(f"Installing 'oldest' available kernel {pkgs[0]}...")
+        vm.run_vm_command(f"apt install -y {pkgs[0]}")
+        print(f"copying the kernel switcher to the VM...")
+        subprocess.run(
+            ["lxc", "file", "push", "switch_kernel.py", "vm-test/root/"]
+        )
+        print("Running the kernel switcher...")
+        new_kernel = pkgs[0].replace("linux-image-", "")
+        vm.run_vm_command(f"python3 switch_kernel.py {new_kernel}")
+        print("Rebooting VM...")
+        vm.run_vm_command("reboot")
+        # we have to wait a few seconds to let the VM reboot
+        time.sleep(3)
+        print("Waiting for VM to come back...")
+        vm.wait_for_vm_ready()
+        new_kernel = vm.run_vm_command("uname -r")
+        print(f"New kernel: {new_kernel}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kernel-switcher/test_in_lxd_vm.py
+++ b/kernel-switcher/test_in_lxd_vm.py
@@ -1,4 +1,18 @@
-#!usr/bin/env python3
+#!/usr/bin/env python3
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """
 This is a test script for the kernel switcher.
 It uses LXD to create a VM in which the test script runs this sequence:

--- a/kernel-switcher/test_switch_kernel.py
+++ b/kernel-switcher/test_switch_kernel.py
@@ -1,0 +1,454 @@
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import subprocess
+import unittest
+
+from unittest.mock import call, mock_open, patch
+
+from switch_kernel import assert_root
+from switch_kernel import find_menuentry_for_kernel
+from switch_kernel import get_grub_cfg_contents
+from switch_kernel import get_grub_default_contents
+from switch_kernel import get_submenu_entry
+from switch_kernel import main
+from switch_kernel import parse_args
+from switch_kernel import update_grub_default_contents
+
+
+class TestAssertRoot(unittest.TestCase):
+    @patch("os.geteuid")
+    def test_root_user(self, mock_geteuid):
+        """Test behavior when the user is root."""
+        mock_geteuid.return_value = 0
+
+        try:
+            assert_root()
+        except SystemExit as e:
+            self.fail("assert_root() raised SystemExit unexpectedly!")
+
+    @patch("os.geteuid")
+    def test_non_root_user(self, mock_geteuid):
+        """Check if program exits with an error when the EUID is 1001."""
+        mock_geteuid.return_value = 1001
+
+        with self.assertRaises(SystemExit) as context:
+            assert_root()
+
+        self.assertEqual(
+            str(context.exception), "This program must be run as root."
+        )
+
+
+class TestFindMenuentryForKernel(unittest.TestCase):
+    def test_find_correct_menuentry(self):
+        grub_entry = (
+            "menuentry 'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
+            "--class gnu-linux --class gnu --class os $menuentry_id_option "
+            "'gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-"
+            "f565c524c2a6' {"
+        )
+        correct_match = (
+            "gnulinux-5.4.0-80-generic-advanced-"
+            "aca31037-7571-415c-b666-f565c524c2a6"
+        )
+
+        match = find_menuentry_for_kernel("5.4.0-80", grub_entry)
+        self.assertEqual(match, correct_match)
+
+    def test_raises_system_exit_for_no_menuentry(self):
+        with self.assertRaises(SystemExit) as context:
+            find_menuentry_for_kernel("5.4.0-80", "foo")
+
+        self.assertEqual(
+            str(context.exception), "Could not find kernel in grub.cfg"
+        )
+
+    def test_keyword_at_different_positions(self):
+        grub_entry = (
+            "menuentry 'with Linux Ubuntu, 5.4.0-80-generic' --class ubuntu "
+            "--class gnu-linux --class gnu --class os $menuentry_id_option "
+            "'gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-"
+            "f565c524c2a6' {"
+        )
+        correct_match = (
+            "gnulinux-5.4.0-80-generic-advanced-"
+            "aca31037-7571-415c-b666-f565c524c2a6"
+        )
+        match = find_menuentry_for_kernel("5.4.0-80", grub_entry)
+        self.assertEqual(match, correct_match)
+
+    def test_avoid_recovery(self):
+        grub_entry = (
+            "menuentry 'with Linux Ubuntu, 5.4.0-80-generic-recovery' "
+            "--class ubuntu --class gnu-linux --class gnu --class os "
+            "$menuentry_id_option 'gnulinux-recovery-5.4.0-80-generic-"
+            "advanced-aca31037-7571-415c-b666-f565c524c2a6' {"
+        )
+        with self.assertRaises(SystemExit) as context:
+            find_menuentry_for_kernel("5.4.0-80", grub_entry)
+        self.assertEqual(
+            str(context.exception), "Could not find kernel in grub.cfg"
+        )
+
+    def test_multiple_matches(self):
+        grub_entries = (
+            "menuentry 'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
+            "--class gnu-linux --class gnu --class os $menuentry_id_option "
+            "'gnulinux-5.4.0-80-generic-advanced-first' {"
+            "\n"
+            "menuentry 'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
+            "--class gnu-linux --class gnu --class os $menuentry_id_option "
+            "'gnulinux-5.4.0-80-generic-advanced-second' {"
+        )
+        match = find_menuentry_for_kernel("5.4.0-80", grub_entries)
+        self.assertEqual(match, "gnulinux-5.4.0-80-generic-advanced-first")
+
+    def test_no_menuentry_keyword(self):
+        grub_entry = (
+            "'Ubuntu, with Linux 5.4.0-80-generic' --class ubuntu "
+            "--class gnu-linux --class gnu --class os $changed_id_option "
+            "'gnulinux-5.4.0-80-generic-advanced-aca31037-7571-415c-b666-"
+            "f565c524c2a6' {"
+        )
+        with self.assertRaises(SystemExit) as context:
+            find_menuentry_for_kernel("5.4.0-80", grub_entry)
+        self.assertEqual(
+            str(context.exception), "Could not find kernel in grub.cfg"
+        )
+
+    def test_empty_input(self):
+        with self.assertRaises(SystemExit) as context:
+            find_menuentry_for_kernel("", "")
+        self.assertEqual(
+            str(context.exception), "Could not find kernel in grub.cfg"
+        )
+
+
+class TestGetSubmenuEntry(unittest.TestCase):
+    def test_valid_submenu_entry(self):
+        grub_entry = (
+            "submenu 'Advanced options for Ubuntu' $menuentry_id_option "
+            "'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6' {"
+        )
+        expected = "gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6"
+        result = get_submenu_entry(grub_entry)
+        self.assertEqual(result, expected)
+
+    def test_no_submenu_entry(self):
+        with self.assertRaises(SystemExit) as context:
+            get_submenu_entry("foo")
+        self.assertEqual(
+            str(context.exception), "Could not find submenu entry in grub.cfg"
+        )
+
+    # Additional tests:
+
+    def test_submenu_without_advanced(self):
+        grub_entry = (
+            "submenu 'Options for Ubuntu' $menuentry_id_option "
+            "'gnulinux-options-aca31037-7571-415c-b666-f565c524c2a6' {"
+        )
+
+        with self.assertRaises(SystemExit) as context:
+            get_submenu_entry("foo")
+        self.assertEqual(
+            str(context.exception), "Could not find submenu entry in grub.cfg"
+        )
+
+    def test_multiple_submenu_entries(self):
+        grub_entries = (
+            "submenu 'Options for Linux' $menuentry_id_option "
+            "'gnulinux-1' {"
+            "\n"
+            "submenu 'Advanced options for Ubuntu' $menuentry_id_option "
+            "'gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6' {"
+        )
+        expected = "gnulinux-advanced-aca31037-7571-415c-b666-f565c524c2a6"
+        result = get_submenu_entry(grub_entries)
+        self.assertEqual(result, expected)
+
+    def test_invalid_submenu_format(self):
+        grub_entry = "submenu 'Options for Ubuntu'"
+        with self.assertRaises(SystemExit) as context:
+            get_submenu_entry(grub_entry)
+        self.assertEqual(
+            str(context.exception), "Could not find submenu entry in grub.cfg"
+        )
+
+    def test_empty_input(self):
+        with self.assertRaises(SystemExit) as context:
+            get_submenu_entry("")
+        self.assertEqual(
+            str(context.exception), "Could not find submenu entry in grub.cfg"
+        )
+
+
+class TestGetGrubCfgContents(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open, read_data="test data")
+    def test_returns_contents_of_grub_cfg(self, mock_file):
+        contents = get_grub_cfg_contents()
+        mock_file.assert_called_once_with("/boot/grub/grub.cfg", "rt")
+        self.assertEqual(contents, "test data")
+
+    @patch("builtins.open", side_effect=OSError("file not found"))
+    def test_raises_system_exit_if_file_not_found(self, mock_file):
+        with self.assertRaises(SystemExit) as context:
+            get_grub_cfg_contents()
+        self.assertEqual(
+            str(context.exception),
+            "Could not read /boot/grub/grub.cfg: file not found",
+        )
+
+
+class TestGetGrubDefaultContents(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open, read_data="test data")
+    def test_returns_contents_of_grub_default(self, mock_file):
+        contents = get_grub_default_contents()
+        mock_file.assert_called_once_with("/etc/default/grub", "rt")
+        self.assertEqual(contents, "test data")
+
+    @patch("builtins.open", side_effect=OSError("file not found"))
+    def test_raises_system_exit_if_file_not_found(self, mock_file):
+        with self.assertRaises(SystemExit) as context:
+            get_grub_default_contents()
+        self.assertEqual(
+            str(context.exception),
+            "Could not read /etc/default/grub: file not found",
+        )
+
+
+class TestUpdateGrubDefaultContents(unittest.TestCase):
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("subprocess.run")
+    def test_writes_and_updates_grub(self, mock_run, mock_file):
+        new_contents = "GRUB_DEFAULT=0\nGRUB_TIMEOUT=5\n"
+        update_grub_default_contents(new_contents)
+        mock_file.assert_called_once_with("/etc/default/grub", "wt")
+        mock_file().write.assert_called_once_with(new_contents)
+        mock_run.assert_called_once_with(["update-grub"])
+
+    @patch("builtins.open", side_effect=OSError("file not found"))
+    def test_raises_system_exit_if_file_not_found(self, mock_file):
+        with self.assertRaises(SystemExit) as context:
+            update_grub_default_contents("GRUB_DEFAULT=0\nGRUB_TIMEOUT=5\n")
+        self.assertEqual(
+            str(context.exception),
+            "Could not write /etc/default/grub: file not found",
+        )
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_parse_args(self):
+        argv = ["switch_kernel.py", "5.4.0-80"]
+        kernel, dry_run = parse_args(argv)
+        self.assertEqual(kernel, "5.4.0-80")
+        self.assertFalse(dry_run)
+
+    def test_parse_args_with_dry_run(self):
+        argv = ["switch_kernel.py", "5.4.0-80", "--dry-run"]
+        kernel, dry_run = parse_args(argv)
+        self.assertEqual(kernel, "5.4.0-80")
+        self.assertTrue(dry_run)
+
+
+class TestMain(unittest.TestCase):
+    @patch("switch_kernel.parse_args")
+    @patch("switch_kernel.get_grub_cfg_contents")
+    @patch("switch_kernel.get_submenu_entry")
+    @patch("switch_kernel.find_menuentry_for_kernel")
+    @patch("switch_kernel.get_grub_default_contents")
+    @patch("switch_kernel.update_grub_default_contents")
+    @patch("builtins.print")
+    @patch("os.path.exists")
+    @patch("os.remove")
+    def test_main(
+        self,
+        mock_remove,
+        mock_exists,
+        mock_print,
+        mock_update_grub_default_contents,
+        mock_get_grub_default_contents,
+        mock_find_menuentry_for_kernel,
+        mock_get_submenu_entry,
+        mock_get_grub_cfg_contents,
+        mock_parse_args,
+    ):
+        # Set up mocks
+        mock_parse_args.return_value = ("5.4.0-80", False)
+        mock_get_grub_cfg_contents.return_value = "test grub cfg contents"
+        mock_get_submenu_entry.return_value = "test submenu entry"
+        mock_find_menuentry_for_kernel.return_value = "test menuentry"
+        mock_get_grub_default_contents.return_value = (
+            "GRUB_DEFAULT=test grub default contents"
+        )
+        mock_exists.return_value = True
+
+        # Call main
+        main([])
+
+        # Check that the expected functions were called with the expected arguments
+        mock_parse_args.assert_called_once_with([])
+        mock_get_grub_cfg_contents.assert_called_once_with()
+        mock_get_submenu_entry.assert_called_once_with(
+            "test grub cfg contents"
+        )
+        mock_find_menuentry_for_kernel.assert_called_once_with(
+            "5.4.0-80", "test grub cfg contents"
+        )
+        mock_get_grub_default_contents.assert_called_once_with()
+        mock_remove.assert_called_once_with(
+            "/etc/default/grub.d/40-force-partuuid.cfg"
+        )
+        mock_update_grub_default_contents.assert_called_once_with(
+            "GRUB_DEFAULT='test submenu entry>test menuentry'"
+        )
+
+        # Check that the expected output was printed
+        mock_print.assert_has_calls(
+            [
+                call("Reading existing kernel from /boot/grub/grub.cfg..."),
+                call("Found submenu entry: test submenu entry"),
+                call("Searching for menuentry for kernel 5.4.0-80..."),
+                call("Found menuentry: test menuentry"),
+                call("Removing 'force partuuid' from grub config..."),
+                call("Setting new default: test submenu entry>test menuentry"),
+            ]
+        )
+
+    @patch("switch_kernel.parse_args")
+    @patch("switch_kernel.get_grub_cfg_contents")
+    @patch("switch_kernel.get_submenu_entry")
+    @patch("switch_kernel.find_menuentry_for_kernel")
+    @patch("switch_kernel.get_grub_default_contents")
+    @patch("switch_kernel.update_grub_default_contents")
+    @patch("builtins.print")
+    @patch("os.path.exists")
+    @patch("os.remove")
+    def test_main_no_partuuid(
+        self,
+        mock_remove,
+        mock_exists,
+        mock_print,
+        mock_update_grub_default_contents,
+        mock_get_grub_default_contents,
+        mock_find_menuentry_for_kernel,
+        mock_get_submenu_entry,
+        mock_get_grub_cfg_contents,
+        mock_parse_args,
+    ):
+        # Set up mocks
+        mock_parse_args.return_value = ("5.4.0-80", False)
+        mock_get_grub_cfg_contents.return_value = "test grub cfg contents"
+        mock_get_submenu_entry.return_value = "test submenu entry"
+        mock_find_menuentry_for_kernel.return_value = "test menuentry"
+        mock_get_grub_default_contents.return_value = (
+            "GRUB_DEFAULT=test grub default contents"
+        )
+        mock_exists.return_value = False
+
+        # Call main
+        main([])
+
+        # Check that the expected functions were called with the expected arguments
+        mock_parse_args.assert_called_once_with([])
+        mock_get_grub_cfg_contents.assert_called_once_with()
+        mock_get_submenu_entry.assert_called_once_with(
+            "test grub cfg contents"
+        )
+        mock_find_menuentry_for_kernel.assert_called_once_with(
+            "5.4.0-80", "test grub cfg contents"
+        )
+        mock_get_grub_default_contents.assert_called_once_with()
+        mock_remove.assert_not_called()
+        mock_update_grub_default_contents.assert_called_once_with(
+            "GRUB_DEFAULT='test submenu entry>test menuentry'"
+        )
+
+        # Check that the expected output was printed
+        mock_print.assert_has_calls(
+            [
+                call("Reading existing kernel from /boot/grub/grub.cfg..."),
+                call("Found submenu entry: test submenu entry"),
+                call("Searching for menuentry for kernel 5.4.0-80..."),
+                call("Found menuentry: test menuentry"),
+                call("Removing 'force partuuid' from grub config..."),
+                call("partuuid.cfg not found, not removing."),
+                call("Setting new default: test submenu entry>test menuentry"),
+            ]
+        )
+
+    @patch("switch_kernel.parse_args")
+    @patch("switch_kernel.get_grub_cfg_contents")
+    @patch("switch_kernel.get_submenu_entry")
+    @patch("switch_kernel.find_menuentry_for_kernel")
+    @patch("switch_kernel.get_grub_default_contents")
+    @patch("switch_kernel.update_grub_default_contents")
+    @patch("builtins.print")
+    @patch("os.path.exists")
+    @patch("os.remove")
+    def test_main_dry_run(
+        self,
+        mock_remove,
+        mock_exists,
+        mock_print,
+        mock_update_grub_default_contents,
+        mock_get_grub_default_contents,
+        mock_find_menuentry_for_kernel,
+        mock_get_submenu_entry,
+        mock_get_grub_cfg_contents,
+        mock_parse_args,
+    ):
+        # Set up mocks
+        mock_parse_args.return_value = ("5.4.0-80", True)
+        mock_get_grub_cfg_contents.return_value = "test grub cfg contents"
+        mock_get_submenu_entry.return_value = "test submenu entry"
+        mock_find_menuentry_for_kernel.return_value = "test menuentry"
+        mock_get_grub_default_contents.return_value = (
+            "GRUB_DEFAULT=test grub default contents"
+        )
+
+        # Call main
+        main([])
+
+        # Check that the expected functions were called with the expected arguments
+        mock_parse_args.assert_called_once_with([])
+        mock_get_grub_cfg_contents.assert_called_once_with()
+        mock_get_submenu_entry.assert_called_once_with(
+            "test grub cfg contents"
+        )
+        mock_find_menuentry_for_kernel.assert_called_once_with(
+            "5.4.0-80", "test grub cfg contents"
+        )
+        mock_get_grub_default_contents.assert_called_once_with()
+        mock_remove.assert_not_called()
+        mock_update_grub_default_contents.assert_not_called()
+
+        # Check that the expected output was printed
+        mock_print.assert_has_calls(
+            [
+                call("Reading existing kernel from /boot/grub/grub.cfg..."),
+                call("Found submenu entry: test submenu entry"),
+                call("Searching for menuentry for kernel 5.4.0-80..."),
+                call("Found menuentry: test menuentry"),
+                call("Removing 'force partuuid' from grub config..."),
+                call("Dry run, not removing the partuuid.cfg file."),
+                call("Setting new default: test submenu entry>test menuentry"),
+                call("Dry run, not writing to grub config."),
+                call("Would have written:"),
+                call("GRUB_DEFAULT='test submenu entry>test menuentry'"),
+            ]
+        )


### PR DESCRIPTION
# Ubuntu Kernel Switcher

## Summary

Ubuntu Kernel Switcher is a utility that lets you switch to a specific
kernel. Notably, post-switch, that kernel becomes the default, ensuring
it remains after system updates introduce new kernels.

## Usage

To run the tool, use invoke `switch_kernel.py` with the desired kernel
as the argument. Examples:

- `switch_kernel.py 6.5`
- `switch_kernel.py generic`
- `switch_kernel.py 6.2.0-33-generic`
- `switch_kernel.py realtime`

Note how the argument is fuzzy matched. But beware, first match will be used
so for instance if `realtime` is used as the argument, first grub's menuentry
that matches `realtime` will be used.

## Testing

There `test_in_lxd_vm.py` is a script that tests the tool inside LXD's VMs.
(So it's somewhat safe to be used).

Resolves: https://warthogs.atlassian.net/jira/software/c/projects/CER/boards/534?selectedIssue=CHECKBOX-904