### PR TITLE
Script to move a target branch given a version string

### DIFF
--- a/snap-update-tools/move_branch_by_version.py
+++ b/snap-update-tools/move_branch_by_version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+This script moves a branch HEAD from the current location
+to an offset calculated from a version string in the form
+of vX.Y.Z-devAA, where AA is the ammount of commits
+
+Example usage:
+    python3 move_beta_branch.py repository_path beta_validation version_string
+"""
+
+import sys
+
+from argparse import ArgumentParser, ArgumentTypeError
+from subprocess import check_output, check_call
+
+
+def get_latest_tag(repo_path: str):
+    return check_output(
+        ["git", "describe", "--tags", "--abbrev=0"], cwd=repo_path, text=True
+    ).strip()
+
+
+def get_history_since(tag: str, repo_path: str):
+    return check_output(
+        [
+            "git",
+            "log",
+            "--pretty=format:'%H'",
+            "--no-patch",
+            f"{tag}..origin/main",
+        ],
+        text=True,
+        cwd=repo_path,
+    ).splitlines()
+
+
+def move_branch_head(branch_name, revision, repo_path: str):
+    check_call(["git", "checkout", branch_name], cwd=repo_path)
+    check_call(["git", "reset", "--hard", revision], cwd=repo_path)
+    # Note: the update should move the branch HEAD ahead. If this is
+    #       the case, there is no need to push --force, else something
+    #       went terribly wrong, we must fail here
+    check_call(["git", "push", "origin", branch_name], cwd=repo_path)
+
+
+def get_offset_from_version(version: str) -> int:
+    return int(version.rsplit("dev", 1)[1])
+
+
+def get_revision_at_offset(version: str, repo_path: str):
+    tag = get_latest_tag(repo_path)
+    history = get_history_since(tag, repo_path)
+    offset = get_offset_from_version(version)
+    return history[-offset]  # history is tag->now, not now->tag
+
+
+def move_beta_branch(branch_name: str, version: str, repo_path: str):
+    target_revision = get_revision_at_offset(version, repo_path)
+    move_branch_head(branch_name, target_revision, repo_path)
+
+
+def parse_args(argv):
+    def version_validator_type(arg):
+        if "dev" in arg:
+            return arg
+        raise ArgumentTypeError(f"{arg} is not a valid version")
+
+    parser = ArgumentParser()
+    parser.add_argument("repository_path", help="Path to the repository")
+    parser.add_argument("branch_name", help="Name of the branch to move")
+    parser.add_argument(
+        "version",
+        help="Version string in the format vX.Y.Z-devAA",
+        type=version_validator_type,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    move_beta_branch(args.branch_name, args.version, args.repository_path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/snap-update-tools/test_move_branch_by_version.py
+++ b/snap-update-tools/test_move_branch_by_version.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch, call
+import move_branch_by_version
+
+
+class TestMoveBetaBranch(unittest.TestCase):
+    def test_get_offset_from_version(self):
+        version = "v1.2.3-dev45"
+
+        result = move_branch_by_version.get_offset_from_version(version)
+
+        self.assertEqual(result, 45)
+
+    @patch("move_branch_by_version.get_latest_tag")
+    @patch("move_branch_by_version.get_history_since")
+    def test_get_revision_at_offset(
+        self, mock_get_history_since, mock_get_latest_tag
+    ):
+        mock_get_latest_tag.return_value = "v1.0.0"
+        mock_get_history_since.return_value = [
+            "tag_hash + 3",
+            "tag_hash + 2",
+            "tag_hash + 1",
+            # here would be hash of tag
+        ]
+
+        result = move_branch_by_version.get_revision_at_offset(
+            "v1.2.3-dev2", "/path/to/repo"
+        )
+
+        self.assertEqual(result, "tag_hash + 2")
+
+    @patch("move_branch_by_version.get_latest_tag")
+    @patch("move_branch_by_version.get_history_since")
+    @patch("move_branch_by_version.check_call")
+    def test_main_happy(
+        self, mock_check_call, mock_get_history_since, mock_get_latest_tag
+    ):
+        mock_get_latest_tag.return_value = "v1.0.0"
+        mock_get_history_since.return_value = [
+            "tag_hash + 3",
+            "tag_hash + 2",
+            "tag_hash + 1",
+        ]
+
+        move_branch_by_version.main(
+            ["/path/to/repo", "beta_validation", "v1.1.0-dev3"]
+        )
+
+        self.assertIn(
+            call(
+                ["git", "reset", "--hard", "tag_hash + 3"], cwd="/path/to/repo"
+            ),
+            mock_check_call.call_args_list,
+        )
+
+    @patch("move_branch_by_version.get_latest_tag")
+    @patch("move_branch_by_version.get_history_since")
+    @patch("move_branch_by_version.check_call")
+    def test_main_unhappy(
+        self, mock_check_call, mock_get_history_since, mock_get_latest_tag
+    ):
+        with self.assertRaises(SystemExit):
+            move_branch_by_version.main(
+                ["/path/to/repo", "beta_validation", "v1.1.0"]
+            )


### PR DESCRIPTION
To create the last piece of the canary validation pipeline we need a way to communicate back the result of the validation to the Checkbox repository. We have decided to do so by moving the head of a branch called beta_validation to the latest validated commit in the repository.

This introduces a script that is able to move the HEAD of a branch to the correct revision, calculating it from the latest tag and the provided version string. This is connected to: https://github.com/canonical/hwcert-jenkins-tools/pull/8.

The idea is that we first get the latest version in the store, then we use this script in a fresh clone of the Checkbox repository to move the tag like this:
```bash
$ git clone https://github.com/canonical/checkbox /path/to/repo
$ [...] # setup the credentials/repo identity
$ export CURRENT_VERSION="`./get_version_store_snap checkbox edge`"
$ ./move_branch_by_version.py /path/to/repo beta_validation $CURRENT_VERSION
```

Resolves CHECKBOX-1093