### PR TITLE
Add wait for debs

### DIFF
--- a/ppa-update-tools/README.md
+++ b/ppa-update-tools/README.md
@@ -4,8 +4,7 @@ This directory contains programs that help test checkbox PPAs.
 
 ## ppa_version_published.py
 
-This program checks whether a specified package is available in launchpad
-for a the PPA correspondent to a snap channel
+This program checks whether a specified package is available in a given PPA.
 
 Characteristics include package name, deb name, ubuntu versions and 
 architectures.

--- a/ppa-update-tools/README.md
+++ b/ppa-update-tools/README.md
@@ -1,0 +1,19 @@
+# Ppa update tools
+
+This directory contains programs that help test checkbox PPAs.
+
+## ppa_version_published.py
+
+This program checks whether a specified package is available in launchpad
+for a the PPA correspondent to a snap channel
+
+Characteristics include package name, deb name, ubuntu versions and 
+architectures.
+See the top-level module docstring of the program for more details.
+
+Example usage:
+`python3 ppa_version_published.py 2.10.09.2-dev5-123abcdef checkbox-ppas-for-canary.yaml`
+
+## test_* files
+
+Those are files containing automated tests for the respective modules.

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -1,46 +1,46 @@
 channel: edge
-required-packages:
+required-debs:
  - name: checkbox-ng
    deb-name: checkbox-ng
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]
    
  - name: checkbox-provider-base
    deb-name: checkbox-provider-base
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-certification-client
    deb-name: checkbox-provider-certification-client
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]
 
  - name: checkbox-provider-certification-server
    deb-name: checkbox-provider-certification-server
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]
 
  - name: checkbox-provider-gpgpu
    deb-name: checkbox-provider-gpgpu
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]
 
  - name: checkbox-provider-resource
    deb-name: checkbox-provider-resource
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-sru
    deb-name: checkbox-provider-sru
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-tpm2
    deb-name: checkbox-provider-tpm2
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]
 
  - name: checkbox-support
    deb-name: python3-checkbox-support
-   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
    architectures: [ all ]

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -2,45 +2,45 @@ channel: edge
 required-debs:
  - name: checkbox-ng
    deb-name: checkbox-ng
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
    
  - name: checkbox-provider-base
    deb-name: checkbox-provider-base
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-certification-client
    deb-name: checkbox-provider-certification-client
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
  - name: checkbox-provider-certification-server
    deb-name: checkbox-provider-certification-server
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
  - name: checkbox-provider-gpgpu
    deb-name: checkbox-provider-gpgpu
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
  - name: checkbox-provider-resource
    deb-name: checkbox-provider-resource
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-sru
    deb-name: checkbox-provider-sru
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
 
  - name: checkbox-provider-tpm2
    deb-name: checkbox-provider-tpm2
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
  - name: checkbox-support
    deb-name: python3-checkbox-support
-   versions: [ 18.04, 20.04, 22.04, 23.04, 23.10, 24.04 ]
+   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -9,10 +9,13 @@ required-packages:
    package: checkbox-provider-base
    versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
-   # The package is not built in 18.04 for riscv64
-   include: 
-      versions: [ "18.04"]
-      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
+
+   # Launchpad doesn't build riscv64 packages for releases 18.04 and older,
+   # so we need to define it explicitly for non-riscv64 archs.
+ - source: checkbox-provider-base
+   package: checkbox-provider-base
+   versions: [ "18.04"]
+   architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-certification-client
    package: checkbox-provider-certification-client
@@ -33,19 +36,25 @@ required-packages:
    package: checkbox-provider-resource
    versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
-   # The package is not built in 18.04 for riscv64
-   include: 
-      versions: [ "18.04"]
-      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
+
+   # Launchpad doesn't build riscv64 packages for releases 18.04 and older,
+   # so we need to define it explicitly for non-riscv64 archs.
+ - source: checkbox-provider-resource
+   package: checkbox-provider-resource
+   versions: [ "18.04"]
+   architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-sru
    package: checkbox-provider-sru
    versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
-   # The package is not built in 18.04 for riscv64
-   include: 
-      versions: [ "18.04"]
-      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
+
+   # Launchpad doesn't build riscv64 packages for releases 18.04 and older,
+   # so we need to define it explicitly for non-riscv64 archs.
+ - source: checkbox-provider-sru
+   package: checkbox-provider-sru
+   versions: [ "18.04"]
+   architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-tpm2
    package: checkbox-provider-tpm2

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -7,10 +7,12 @@ required-packages:
    
  - source: checkbox-provider-base
    package: checkbox-provider-base
-   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
+   versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
-   exclude: [["18.04", riscv64]]
+   include: 
+      versions: [ "18.04"]
+      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-certification-client
    package: checkbox-provider-certification-client
@@ -29,17 +31,21 @@ required-packages:
 
  - source: checkbox-provider-resource
    package: checkbox-provider-resource
-   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
+   versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
-   exclude: [["18.04", riscv64]]
+   include: 
+      versions: [ "18.04"]
+      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-sru
    package: checkbox-provider-sru
-   versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
+   versions: [ "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
-   exclude: [["18.04", riscv64]]
+   include: 
+      versions: [ "18.04"]
+      architectures: [ amd64, arm64, armhf, ppc64el, s390x ]
 
  - source: checkbox-provider-tpm2
    package: checkbox-provider-tpm2

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -1,52 +1,52 @@
 channel: edge
-required-debs:
- - name: checkbox-ng
-   deb-name: checkbox-ng
+required-packages:
+ - source: checkbox-ng
+   package: checkbox-ng
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
    
- - name: checkbox-provider-base
-   deb-name: checkbox-provider-base
+ - source: checkbox-provider-base
+   package: checkbox-provider-base
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
    exclude: [["18.04", riscv64]]
 
- - name: checkbox-provider-certification-client
-   deb-name: checkbox-provider-certification-client
+ - source: checkbox-provider-certification-client
+   package: checkbox-provider-certification-client
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
- - name: checkbox-provider-certification-server
-   deb-name: checkbox-provider-certification-server
+ - source: checkbox-provider-certification-server
+   package: checkbox-provider-certification-server
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
- - name: checkbox-provider-gpgpu
-   deb-name: checkbox-provider-gpgpu
+ - source: checkbox-provider-gpgpu
+   package: checkbox-provider-gpgpu
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
- - name: checkbox-provider-resource
-   deb-name: checkbox-provider-resource
+ - source: checkbox-provider-resource
+   package: checkbox-provider-resource
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
    exclude: [["18.04", riscv64]]
 
- - name: checkbox-provider-sru
-   deb-name: checkbox-provider-sru
+ - source: checkbox-provider-sru
+   package: checkbox-provider-sru
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
    # The package is not built in 18.04 for riscv64
    exclude: [["18.04", riscv64]]
 
- - name: checkbox-provider-tpm2
-   deb-name: checkbox-provider-tpm2
+ - source: checkbox-provider-tpm2
+   package: checkbox-provider-tpm2
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]
 
- - name: checkbox-support
-   deb-name: python3-checkbox-support
+ - source: checkbox-support
+   package: python3-checkbox-support
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ all ]

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -9,6 +9,8 @@ required-debs:
    deb-name: checkbox-provider-base
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+   # The package is not built in 18.04 for riscv64
+   exclude: [["18.04", riscv64]]
 
  - name: checkbox-provider-certification-client
    deb-name: checkbox-provider-certification-client
@@ -29,11 +31,15 @@ required-debs:
    deb-name: checkbox-provider-resource
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+   # The package is not built in 18.04 for riscv64
+   exclude: [["18.04", riscv64]]
 
  - name: checkbox-provider-sru
    deb-name: checkbox-provider-sru
    versions: [ "18.04", "20.04", "22.04", "23.04", "23.10", "24.04" ]
    architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+   # The package is not built in 18.04 for riscv64
+   exclude: [["18.04", riscv64]]
 
  - name: checkbox-provider-tpm2
    deb-name: checkbox-provider-tpm2

--- a/ppa-update-tools/checkbox-ppas-for-canary.yaml
+++ b/ppa-update-tools/checkbox-ppas-for-canary.yaml
@@ -1,0 +1,46 @@
+channel: edge
+required-packages:
+ - name: checkbox-ng
+   deb-name: checkbox-ng
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]
+   
+ - name: checkbox-provider-base
+   deb-name: checkbox-provider-base
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+
+ - name: checkbox-provider-certification-client
+   deb-name: checkbox-provider-certification-client
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]
+
+ - name: checkbox-provider-certification-server
+   deb-name: checkbox-provider-certification-server
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]
+
+ - name: checkbox-provider-gpgpu
+   deb-name: checkbox-provider-gpgpu
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]
+
+ - name: checkbox-provider-resource
+   deb-name: checkbox-provider-resource
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+
+ - name: checkbox-provider-sru
+   deb-name: checkbox-provider-sru
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ amd64, arm64, armhf, ppc64el, riscv64, s390x ]
+
+ - name: checkbox-provider-tpm2
+   deb-name: checkbox-provider-tpm2
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]
+
+ - name: checkbox-support
+   deb-name: python3-checkbox-support
+   versions: [ 18.04.1, 20.04.1, 22.04.1, 23.04.1, 23.10.1, 24.04.1 ]
+   architectures: [ all ]

--- a/ppa-update-tools/ppa_version_published.py
+++ b/ppa-update-tools/ppa_version_published.py
@@ -69,20 +69,7 @@ def get_package_specs(yaml_content: dict, version: str) -> list[PackageSpec]:
                         arch,
                     )
                 )
-        # Special handling for the 'include' field if it exists
-        # This is required because ubuntu 18.04 does not build for riscv64
-        if "include" in package:
-            for ubuntu_version in package["include"]["versions"]:
-                for arch in package["include"]["architectures"]:
-                    package_specs.append(
-                        PackageSpec(
-                            package["source"],
-                            package["package"],
-                            version,
-                            ubuntu_version,
-                            arch,
-                        )
-                    )
+    package_specs.sort()
     return package_specs
 
 

--- a/ppa-update-tools/ppa_version_published.py
+++ b/ppa-update-tools/ppa_version_published.py
@@ -56,7 +56,8 @@ def get_package_specs(yaml_content: dict, version: str) -> list[PackageSpec]:
         for package in yaml_content["required-debs"]
         for ubuntu_version in package["versions"]
         for arch in package["architectures"]
-        if (arch != "riscv64" and ubuntu_version != 18.04)
+        # We are excluding the combinations that are not being built
+        if [ubuntu_version, arch] not in package.get("exclude", [])
     ]
 
     return package_specs

--- a/ppa-update-tools/ppa_version_published.py
+++ b/ppa-update-tools/ppa_version_published.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This program checks whether a specified package is available in launchpad
+This program checks whether a specified package is available in a given PPA.
 for a the PPA correspondent to a snap channel
 
 The matrix of all combinations is created and the program peridically checks

--- a/ppa-update-tools/ppa_version_published.py
+++ b/ppa-update-tools/ppa_version_published.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 """
+This program checks whether a specified package is available in launchpad
+for a the PPA correspondent to a snap channel
+
+The matrix of all combinations is created and the program peridically checks
+whether all combinations are available and waits until either all of them are
+available or the timeout is reached.
+The characteristics that can be specified are:
+  - (required and one) name of the package
+  - (required and one) name of the deb file
+  - (required and 1 or more) versions of ubuntu
+  - (required and 1 or more) architectures
 """
+
 
 import argparse
 import requests

--- a/ppa-update-tools/test_ppa_version_published.py
+++ b/ppa-update-tools/test_ppa_version_published.py
@@ -1,0 +1,121 @@
+import requests
+import unittest
+import yaml
+
+from unittest.mock import patch, mock_open
+
+
+from ppa_version_published import (
+    PpaSpec,
+    is_package_available,
+    main,
+)
+
+
+class TestIsPackageAvailable(unittest.TestCase):
+    url_example = (
+        "http://ppa.launchpad.net/checkbox-dev/edge/ubuntu/pool/main/c/"
+        "test/test-deb_1.0_amd64.deb"
+    )
+
+    @patch("requests.head")
+    def test_successful_request(self, mock_head):
+        # Mocking the response from launchpad
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_head.return_value = mock_response
+        result = is_package_available(self.url_example)
+
+        self.assertTrue(result)
+
+    @patch("requests.head")
+    def test_no_package_request(self, mock_head):
+        # Mocking the response from launchpad
+        mock_response = requests.Response()
+        mock_response.status_code = 404
+        mock_head.return_value = mock_response
+        result = is_package_available(self.url_example)
+
+        self.assertFalse(result)
+
+    @patch("requests.head")
+    def test_request_raises_error(self, mock_head):
+        # Mocking the response from launchpad
+        mock_head.side_effect = requests.ConnectionError
+        result = is_package_available(self.url_example)
+        self.assertFalse(result)
+
+
+class TestMainFunction(unittest.TestCase):
+    def setUp(self):
+        self.sample_yaml_content = """
+        channel: edge
+        required-packages:
+          - name: pkg1
+            deb-name: pkg1-deb
+            versions: ["1.0", "2.0"]
+            architectures: ["amd64", "armhf"]
+          - name: pkg2
+            deb-name: pkg2-deb
+            versions: ["1.0", "2.0"]
+            architectures: ["all"]
+        """
+
+    @patch("ppa_version_published.yaml.load")
+    @patch("ppa_version_published.check_packages_availability")
+    def test_argument_parsing(self, mock_check_packages, mock_yaml_load):
+        argv = ["script_name", "1.0", "path/to/file.yaml", "--timeout", "100"]
+
+        mock_yaml_load.return_value = {
+            "channel": "edge",
+            "required-packages": [
+                {
+                    "name": "pkg1",
+                    "deb-name": "pkg1-deb",
+                    "versions": ["1.0", "2.0"],
+                    "architectures": ["amd64", "armhf"],
+                },
+                {
+                    "name": "pkg2",
+                    "deb-name": "pkg2-deb",
+                    "versions": ["1.0", "2.0"],
+                    "architectures": ["all"],
+                },
+            ],
+        }
+
+        m = mock_open()
+        with patch("builtins.open", m):
+            main(argv)
+
+        # check_packages_availability is called with the expected arguments
+        # 6 ppaSpec objects are created (4 for pkg1 and 2 for pkg2)
+        self.assertEqual(len(mock_check_packages.call_args[0][0]), 6)
+        # The channel is edge
+        self.assertEqual(
+            mock_check_packages.call_args[0][1], "edge"
+        )  # timeout value
+        # The timeout is 100
+        self.assertEqual(
+            mock_check_packages.call_args[0][2], 100
+        )  # timeout value
+
+    @patch("ppa_version_published.yaml.load")
+    @patch("ppa_version_published.check_packages_availability")
+    def test_default_timeout(self, mock_check_snaps, mock_yaml_load):
+        # Sample arguments without specifying timeout
+        argv = ["script_name", "1.0", "path/to/file.yaml"]
+
+        m = mock_open(read_data=self.sample_yaml_content)
+
+        with patch("builtins.open", m):
+            # Mocking yaml.load to just return a dictionary based on the sample content
+            mock_yaml_load.return_value = yaml.safe_load(
+                self.sample_yaml_content
+            )
+            main(argv)
+
+        # Ensure check_snaps_availability is called with default timeout value of 300
+        self.assertEqual(
+            mock_check_snaps.call_args[0][2], 300
+        )  # default timeout value

--- a/ppa-update-tools/test_ppa_version_published.py
+++ b/ppa-update-tools/test_ppa_version_published.py
@@ -57,10 +57,12 @@ class TestGetPackageSpecs(unittest.TestCase):
                     "package": "pkg1",
                     "versions": ["20.04", "22.04"],
                     "architectures": ["amd64", "armhf"],
-                    "include": {
-                        "versions": ["18.04"],
-                        "architectures": ["amd64"],
-                    },
+                },
+                {
+                    "source": "src1",
+                    "package": "pkg1",
+                    "versions": ["18.04"],
+                    "architectures": ["amd64"],
                 },
                 {
                     "source": "src2",
@@ -79,18 +81,14 @@ class TestGetPackageSpecs(unittest.TestCase):
         #   - 2 package for src2
         self.assertEqual(len(package_specs), 7)
 
-        # The first package spec is src1
+        # The packages are sorted
         self.assertEqual(package_specs[0].source, "src1")
         self.assertEqual(package_specs[0].package, "pkg1")
         self.assertEqual(package_specs[0].version, "1.0~dev1")
-        self.assertEqual(package_specs[0].ubuntu_version, "20.04")
+        self.assertEqual(package_specs[0].ubuntu_version, "18.04")
         self.assertEqual(package_specs[0].arch, "amd64")
 
         # The inclusion adds only the intended package
-        self.assertTrue(
-            PackageSpec("src1", "pkg1", "1.0~dev1", "18.04", "amd64")
-            in package_specs
-        )
         self.assertFalse(
             PackageSpec("src1", "pkg1", "1.0~dev1", "18.04", "armhf")
             in package_specs
@@ -111,10 +109,12 @@ class TestMainFunction(unittest.TestCase):
                     "package": "pkg1",
                     "versions": ["1.0", "2.0"],
                     "architectures": ["amd64", "armhf"],
-                    "include": {
-                        "versions": ["18.04"],
-                        "architectures": ["amd64"],
-                    },
+                },
+                {
+                    "source": "src1",
+                    "package": "pkg1",
+                    "versions": ["18.04"],
+                    "architectures": ["amd64"],
                 },
                 {
                     "source": "src2",
@@ -156,9 +156,10 @@ class TestMainFunction(unittest.TestCase):
             package: pkg1
             versions: ["1.0", "2.0"]
             architectures: ["amd64", "armhf"]
-            include:
-                versions: ["18.04"],
-                architectures: ["amd64"],
+          - source: src1
+            package: pkg1
+            versions: ["3.0"]
+            architectures: ["amd64""]
         """
 
         m = mock_open(read_data=sample_yaml_content)

--- a/ppa-update-tools/test_ppa_version_published.py
+++ b/ppa-update-tools/test_ppa_version_published.py
@@ -6,8 +6,8 @@ from unittest.mock import patch, mock_open
 
 
 from ppa_version_published import (
-    PpaSpec,
-    is_package_available,
+    url_header_check,
+    get_package_specs,
     main,
 )
 
@@ -24,7 +24,7 @@ class TestIsPackageAvailable(unittest.TestCase):
         mock_response = requests.Response()
         mock_response.status_code = 200
         mock_head.return_value = mock_response
-        result = is_package_available(self.url_example)
+        result = url_header_check(self.url_example)
 
         self.assertTrue(result)
 
@@ -34,7 +34,7 @@ class TestIsPackageAvailable(unittest.TestCase):
         mock_response = requests.Response()
         mock_response.status_code = 404
         mock_head.return_value = mock_response
-        result = is_package_available(self.url_example)
+        result = url_header_check(self.url_example)
 
         self.assertFalse(result)
 
@@ -42,15 +42,46 @@ class TestIsPackageAvailable(unittest.TestCase):
     def test_request_raises_error(self, mock_head):
         # Mocking the response from launchpad
         mock_head.side_effect = requests.ConnectionError
-        result = is_package_available(self.url_example)
+        result = url_header_check(self.url_example)
         self.assertFalse(result)
 
+class TestGetPackageSpecs(unittest.TestCase):
+    def setUp(self):
+        self.sample_yaml_content = {
+                "channel": "edge",
+                "required-debs": [
+                    {
+                        "name": "pkg1",
+                        "deb-name": "pkg1-deb",
+                        "versions": ["20.04", "22.04"],
+                        "architectures": ["amd64", "armhf"],
+                    },
+                    {
+                        "name": "pkg2",
+                        "deb-name": "pkg2-deb",
+                        "versions": ["20.04", "22.04"],
+                        "architectures": ["all"],
+                    },
+                ],
+            }
+        
+    def test_get_package_specs(self):
+        package_specs = get_package_specs(self.sample_yaml_content, "1.0~dev1")
+
+        # 6 PackageSpec objects are created (4 for pkg1 and 2 for pkg2)
+        self.assertEqual(len(package_specs), 6)
+
+        # The first package spec is pkg1
+        self.assertEqual(package_specs[0].name, "pkg1")
+        self.assertEqual(package_specs[0].deb_name, "pkg1-deb")
+        self.assertEqual(package_specs[0].version, "1.0~dev1~ubuntu20.04")
+        self.assertEqual(package_specs[0].arch, "amd64")
 
 class TestMainFunction(unittest.TestCase):
     def setUp(self):
         self.sample_yaml_content = """
         channel: edge
-        required-packages:
+        required-debs:
           - name: pkg1
             deb-name: pkg1-deb
             versions: ["1.0", "2.0"]
@@ -68,7 +99,7 @@ class TestMainFunction(unittest.TestCase):
 
         mock_yaml_load.return_value = {
             "channel": "edge",
-            "required-packages": [
+            "required-debs": [
                 {
                     "name": "pkg1",
                     "deb-name": "pkg1-deb",
@@ -89,7 +120,7 @@ class TestMainFunction(unittest.TestCase):
             main(argv)
 
         # check_packages_availability is called with the expected arguments
-        # 6 ppaSpec objects are created (4 for pkg1 and 2 for pkg2)
+        # 6 PackageSpec objects are created (4 for pkg1 and 2 for pkg2)
         self.assertEqual(len(mock_check_packages.call_args[0][0]), 6)
         # The channel is edge
         self.assertEqual(
@@ -102,20 +133,22 @@ class TestMainFunction(unittest.TestCase):
 
     @patch("ppa_version_published.yaml.load")
     @patch("ppa_version_published.check_packages_availability")
-    def test_default_timeout(self, mock_check_snaps, mock_yaml_load):
+    def test_default_timeout(self, mock_check_packages, mock_yaml_load):
         # Sample arguments without specifying timeout
         argv = ["script_name", "1.0", "path/to/file.yaml"]
 
         m = mock_open(read_data=self.sample_yaml_content)
 
         with patch("builtins.open", m):
-            # Mocking yaml.load to just return a dictionary based on the sample content
+            # Mocking yaml.load to just return a dictionary based on the
+            # sample content
             mock_yaml_load.return_value = yaml.safe_load(
                 self.sample_yaml_content
             )
             main(argv)
 
-        # Ensure check_snaps_availability is called with default timeout value of 300
+        # Ensure check_packages_availability is called with default timeout
+        # value of 300
         self.assertEqual(
-            mock_check_snaps.call_args[0][2], 300
+            mock_check_packages.call_args[0][2], 300
         )  # default timeout value

--- a/ppa-update-tools/test_ppa_version_published.py
+++ b/ppa-update-tools/test_ppa_version_published.py
@@ -57,7 +57,10 @@ class TestGetPackageSpecs(unittest.TestCase):
                     "package": "pkg1",
                     "versions": ["20.04", "22.04"],
                     "architectures": ["amd64", "armhf"],
-                    "exclude": [["22.04", "armhf"]],
+                    "include": {
+                        "versions": ["18.04"],
+                        "architectures": ["amd64"],
+                    },
                 },
                 {
                     "source": "src2",
@@ -71,28 +74,25 @@ class TestGetPackageSpecs(unittest.TestCase):
     def test_get_package_specs(self):
         package_specs = get_package_specs(self.sample_yaml_content, "1.0~dev1")
 
-        # 5 PackageSpec objects are created:
-        #   - 4 packages minus 1 excluded for src1
-        #   - 1 package for src2
-        self.assertEqual(len(package_specs), 5)
+        # 7 PackageSpec objects are created:
+        #   - 4 packages plus 1 included for src1
+        #   - 2 package for src2
+        self.assertEqual(len(package_specs), 7)
 
         # The first package spec is src1
         self.assertEqual(package_specs[0].source, "src1")
         self.assertEqual(package_specs[0].package, "pkg1")
-        self.assertEqual(package_specs[0].version, "1.0~dev1~ubuntu20.04")
+        self.assertEqual(package_specs[0].version, "1.0~dev1")
+        self.assertEqual(package_specs[0].ubuntu_version, "20.04")
         self.assertEqual(package_specs[0].arch, "amd64")
 
-        # The exclusion excludes only the intended package
+        # The inclusion adds only the intended package
         self.assertTrue(
-            PackageSpec("src1", "pkg1", "1.0~dev1~ubuntu22.04", "amd64")
-            in package_specs
-        )
-        self.assertTrue(
-            PackageSpec("src1", "pkg1", "1.0~dev1~ubuntu20.04", "armhf")
+            PackageSpec("src1", "pkg1", "1.0~dev1", "18.04", "amd64")
             in package_specs
         )
         self.assertFalse(
-            PackageSpec("src1", "pkg1", "1.0~dev1~ubuntu22.04", "armhf")
+            PackageSpec("src1", "pkg1", "1.0~dev1", "18.04", "armhf")
             in package_specs
         )
 
@@ -111,7 +111,10 @@ class TestMainFunction(unittest.TestCase):
                     "package": "pkg1",
                     "versions": ["1.0", "2.0"],
                     "architectures": ["amd64", "armhf"],
-                    "exclude": [["2.0", "armhf"]],
+                    "include": {
+                        "versions": ["18.04"],
+                        "architectures": ["amd64"],
+                    },
                 },
                 {
                     "source": "src2",
@@ -127,10 +130,10 @@ class TestMainFunction(unittest.TestCase):
             main(argv)
 
         # check_packages_availability is called with the expected arguments
-        # 5 PackageSpec objects are created:
-        #   - 4 packages minus 1 excluded for src1
-        #   - 1 package for src2
-        self.assertEqual(len(mock_check_packages.call_args[0][0]), 5)
+        # 7 PackageSpec objects are created:
+        #   - 4 packages plus 1 included for src1
+        #   - 2 package for src2
+        self.assertEqual(len(mock_check_packages.call_args[0][0]), 7)
         # The channel is edge
         self.assertEqual(
             mock_check_packages.call_args[0][1], "edge"
@@ -153,7 +156,9 @@ class TestMainFunction(unittest.TestCase):
             package: pkg1
             versions: ["1.0", "2.0"]
             architectures: ["amd64", "armhf"]
-            exclude: [["3.0", "armhf"]]
+            include:
+                versions: ["18.04"],
+                architectures: ["amd64"],
         """
 
         m = mock_open(read_data=sample_yaml_content)


### PR DESCRIPTION

## Description

Added a mechanism to check if a specific deb package is already published

## Resolved issues

[Add a wait_for_debs mechanism to the pipeline trigger job](https://warthogs.atlassian.net/browse/CHECKBOX-933)

## Documentation

Added a readme to the ppa-update-tools folder

## Tests
To run the tests:
```
cd ppa-update-tools
pytest 
```
