### PR TITLE
Enable efi-vars from the kernel switcher

### DIFF
--- a/kernel-switcher/switch_kernel.py
+++ b/kernel-switcher/switch_kernel.py
@@ -148,7 +148,6 @@ def parse_args(argv):
 
     return parser.parse_args(argv[1:])
 
-    return args.kernel[0], args.dry_run, args.enable_efi_vars
 
 def add_efi_opt(cmdline):
     """
@@ -163,20 +162,20 @@ def add_efi_opt(cmdline):
 
     return cmdline + " efi=runtime"
 
-def update_cmd_linux_default(grub_cfg_contents):
+def update_cmd_linux(grub_cfg_contents):
     """
     Goes through the context of the grub config file,
-    finds the line with the `GRUB_CMDLINE_LINUX_DEFAULT` and
+    finds the line with the `GRUB_CMDLINE_LINUX` and
     adds the `efi` option to it.
     """
     output = []
 
     for line in grub_cfg_contents.splitlines():
-        pattern = r'GRUB_CMDLINE_LINUX_DEFAULT="(.*?)"'
+        pattern = r'GRUB_CMDLINE_LINUX="(.*?)"'
         match = re.search(pattern, line)
         if match:
             value = match.group(1)
-            output.append(f'GRUB_CMDLINE_LINUX_DEFAULT="{add_efi_opt(value)}"')
+            output.append(f'GRUB_CMDLINE_LINUX="{add_efi_opt(value)}"')
 
         else:
             output.append(line)
@@ -221,7 +220,7 @@ def main(argv):
         grub_default_contents,
     )
     if enable_efi_vars or kernel.lower() == "realtime":
-        new_grub_default_contents = update_cmd_linux_default(new_grub_default_contents)
+        new_grub_default_contents = update_cmd_linux(new_grub_default_contents)
 
 
     if dry_run:

--- a/kernel-switcher/test_in_lxd_vm.py
+++ b/kernel-switcher/test_in_lxd_vm.py
@@ -158,15 +158,18 @@ def main():
         )
         print("Running the kernel switcher...")
         new_kernel = pkgs[0].replace("linux-image-", "")
-        vm.run_vm_command(f"python3 switch_kernel.py {new_kernel}")
+        vm.run_vm_command(f"python3 switch_kernel.py --enable-efi-vars {new_kernel}")
         print("Rebooting VM...")
         vm.run_vm_command("reboot")
         # we have to wait a few seconds to let the VM reboot
-        time.sleep(3)
+        time.sleep(10)
         print("Waiting for VM to come back...")
         vm.wait_for_vm_ready()
         new_kernel = vm.run_vm_command("uname -r")
         print(f"New kernel: {new_kernel}")
+        kernel_cmdline = vm.run_vm_command("cat /proc/cmdline")
+        if "efi=runtime" not in kernel_cmdline:
+            raise SystemExit("'efi=runtime' not found in kernel cmdline")
 
 
 if __name__ == "__main__":

--- a/kernel-switcher/test_switch_kernel.py
+++ b/kernel-switcher/test_switch_kernel.py
@@ -26,7 +26,7 @@ from switch_kernel import get_submenu_entry
 from switch_kernel import main
 from switch_kernel import parse_args
 from switch_kernel import update_grub_default_contents
-from switch_kernel import update_cmd_linux_default
+from switch_kernel import update_cmd_linux
 
 
 class TestAssertRoot(unittest.TestCase):
@@ -293,16 +293,16 @@ class TestAddEfiOpt(unittest.TestCase):
         before = "quiet efi=noruntime splash"
         self.assertEqual(add_efi_opt(before), "quiet efi=runtime splash")
 
-class TestUpdateCmdLinuxDefault(unittest.TestCase):
-    def test_update_cmd_linux_default_smoke(self):
-        before = "FOO=bar\nGRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\"\nBIZ=baz"
-        after = "FOO=bar\nGRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash efi=runtime\"\nBIZ=baz"
-        self.assertEqual(update_cmd_linux_default(before), after)
+class TestUpdateCmdLinux(unittest.TestCase):
+    def test_update_cmd_linux_smoke(self):
+        before = "FOO=bar\nGRUB_CMDLINE_LINUX=\"quiet splash\"\nBIZ=baz"
+        after = "FOO=bar\nGRUB_CMDLINE_LINUX=\"quiet splash efi=runtime\"\nBIZ=baz"
+        self.assertEqual(update_cmd_linux(before), after)
 
-    def test_update_cmd_linux_default_empty(self):
+    def test_update_cmd_linux_empty(self):
         before = ""
         after = ""
-        self.assertEqual(update_cmd_linux_default(before), after)
+        self.assertEqual(update_cmd_linux(before), after)
 
 
 class TestMain(unittest.TestCase):
@@ -538,7 +538,7 @@ class TestMain(unittest.TestCase):
         mock_find_menuentry_for_kernel.return_value = "test menuentry"
         mock_get_grub_default_contents.return_value = (
             "GRUB_DEFAULT=test grub default contents\n"
-            "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\""
+            "GRUB_CMDLINE_LINUX=\"quiet splash\""
         )
 
         # Call main
@@ -562,7 +562,7 @@ class TestMain(unittest.TestCase):
         #)
         mock_update_grub_default_contents.assert_called_once_with(
             "GRUB_DEFAULT='test submenu entry>test menuentry'\n"
-            "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash efi=runtime\""
+            "GRUB_CMDLINE_LINUX=\"quiet splash efi=runtime\""
         )
 
         # Check that the expected output was printed
@@ -611,7 +611,7 @@ class TestMain(unittest.TestCase):
         mock_find_menuentry_for_kernel.return_value = "test menuentry"
         mock_get_grub_default_contents.return_value = (
             "GRUB_DEFAULT=test grub default contents\n"
-            "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash\""
+            "GRUB_CMDLINE_LINUX=\"quiet splash\""
         )
 
         # Call main
@@ -635,7 +635,7 @@ class TestMain(unittest.TestCase):
         #)
         mock_update_grub_default_contents.assert_called_once_with(
             "GRUB_DEFAULT='test submenu entry>test menuentry'\n"
-            "GRUB_CMDLINE_LINUX_DEFAULT=\"quiet splash efi=runtime\""
+            "GRUB_CMDLINE_LINUX=\"quiet splash efi=runtime\""
         )
 
         # Check that the expected output was printed


### PR DESCRIPTION
This patch introduces an arg to the kernel switcher that, when used, places `efi=runtime` kernel command line argument in the grub config. This value is necessary for the device to be provisionable by MAAS, and when the realtime kernel is used, that option is disabled (the default value for non-realtime kernels is indeed `efi-runtime`).

