### PR TITLE
Update provision_checkbox.sh to fully support any REF (checkbox version)

### DIFF
--- a/provision_checkbox.sh
+++ b/provision_checkbox.sh
@@ -40,7 +40,7 @@ else
     UPDATED=true
 fi
 if [ -n "$REF" ]; then
-    git -C checkbox checkout $REF
+    ./version-published/checkout_to_version.py checkbox "$REF"
     UPDATED=true
 fi
 

--- a/provision_checkbox.sh
+++ b/provision_checkbox.sh
@@ -23,6 +23,7 @@ if ! git clone https://github.com/canonical/checkbox.git; then
     echo "Before pull: $before_pull"
 
     # Perform the pull
+    git -C checkbox switch main
     git -C checkbox pull
 
     # Get the latest commit after pull
@@ -40,7 +41,8 @@ else
     UPDATED=true
 fi
 if [ -n "$REF" ]; then
-    ./version-published/checkout_to_version.py checkbox "$REF"
+    PARENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    $PARENT_DIR/version-published/checkout_to_version.py checkbox "$REF"
     UPDATED=true
 fi
 

--- a/version-published/checkout_to_version.py
+++ b/version-published/checkout_to_version.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+This script checks out a repository to an offset calculated from a version
+string in the form of vX.Y.Z-devAA, where AA is the ammount of commits
+since the latest version tag
+
+Example usage:
+    python3 checkout_to_version.py repository_path version_string
+"""
+
+import sys
+from argparse import ArgumentParser
+from subprocess import check_call
+
+from snap_info_utility import get_revision_at_offset
+
+
+def checkout_to_version(version: str, repository_path: str):
+    revision = get_revision_at_offset(version, repository_path)
+    check_call(["git", "switch", revision, "--detach"], cwd=repository_path)
+
+
+def parse_args(argv):
+    parser = ArgumentParser()
+    parser.add_argument("repository_path", help="Path to the repository")
+    parser.add_argument(
+        "version",
+        help="Version string in the format vX.Y.Z-devAA or vX.Y.Z",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+    checkout_to_version(args.version, args.repository_path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/version-published/move_branch_by_version.py
+++ b/version-published/move_branch_by_version.py
@@ -11,27 +11,9 @@ Example usage:
 import sys
 
 from argparse import ArgumentParser, ArgumentTypeError
-from subprocess import check_output, check_call
+from subprocess import check_call
 
-
-def get_latest_tag(repo_path: str):
-    return check_output(
-        ["git", "describe", "--tags", "--abbrev=0"], cwd=repo_path, text=True
-    ).strip()
-
-
-def get_history_since(tag: str, repo_path: str):
-    return check_output(
-        [
-            "git",
-            "log",
-            "--pretty=format:'%H'",
-            "--no-patch",
-            f"{tag}..origin/main",
-        ],
-        text=True,
-        cwd=repo_path,
-    ).splitlines()
+from snap_info_utility import get_revision_at_offset
 
 
 def move_branch_head(branch_name, revision, repo_path: str):
@@ -41,17 +23,6 @@ def move_branch_head(branch_name, revision, repo_path: str):
     #       the case, there is no need to push --force, else something
     #       went terribly wrong, we must fail here
     check_call(["git", "push", "origin", branch_name], cwd=repo_path)
-
-
-def get_offset_from_version(version: str) -> int:
-    return int(version.rsplit("dev", 1)[1])
-
-
-def get_revision_at_offset(version: str, repo_path: str):
-    tag = get_latest_tag(repo_path)
-    history = get_history_since(tag, repo_path)
-    offset = get_offset_from_version(version)
-    return history[-offset]  # history is tag->now, not now->tag
 
 
 def move_beta_branch(branch_name: str, version: str, repo_path: str):

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -39,6 +39,8 @@ def get_history_since(tag: str, repo_path: str):
 
 
 def get_offset_from_version(version: str) -> int:
+    if "dev" not in version:
+        return 0
     return int(version.rsplit("dev", 1)[1])
 
 

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -31,7 +31,7 @@ def get_history_since(tag: str, repo_path: str):
             "log",
             "--pretty=format:%H",
             "--no-patch",
-            f"{tag}..origin/main",
+            f"{tag}~1..origin/main",
         ],
         text=True,
         cwd=repo_path,
@@ -48,8 +48,10 @@ def get_revision_at_offset(version: str, repo_path: str):
     tag = get_latest_tag(repo_path)
     history = get_history_since(tag, repo_path)
     offset = get_offset_from_version(version)
-    # history is tag->now, not now->tag
-    return history[-offset]
+    # history is now -> tag(inclusive)
+    # raw tag (no dev) is tag so -0 -1 = -1 (latest in history)
+    # dev-1 is tag+1 so -1 -1 = -2 semi lastest in history
+    return history[-offset - 1]
 
 
 def get_latest_tag(repo_path: str):

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -3,6 +3,8 @@ This module contains every utility function shared among multiple
 scripts that fetches information about snaps
 """
 import requests
+from subprocess import check_output
+
 
 def get_snap_info_from_store(snap_name: str) -> dict:
     """
@@ -20,3 +22,35 @@ def get_snap_info_from_store(snap_name: str) -> dict:
         )
 
     return response.json()
+
+
+def get_history_since(tag: str, repo_path: str):
+    return check_output(
+        [
+            "git",
+            "log",
+            "--pretty=format:'%H'",
+            "--no-patch",
+            f"{tag}..origin/main",
+        ],
+        text=True,
+        cwd=repo_path,
+    ).splitlines()
+
+
+def get_offset_from_version(version: str) -> int:
+    return int(version.rsplit("dev", 1)[1])
+
+
+def get_revision_at_offset(version: str, repo_path: str):
+    tag = get_latest_tag(repo_path)
+    history = get_history_since(tag, repo_path)
+    offset = get_offset_from_version(version)
+    # history is tag->now, not now->tag
+    return history[-offset]
+
+
+def get_latest_tag(repo_path: str):
+    return check_output(
+        ["git", "describe", "--tags", "--abbrev=0"], cwd=repo_path, text=True
+    ).strip()

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -48,10 +48,18 @@ def get_revision_at_offset(version: str, repo_path: str):
     tag = get_latest_tag(repo_path)
     history = get_history_since(tag, repo_path)
     offset = get_offset_from_version(version)
-    # history is now -> tag(inclusive)
-    # raw tag (no dev) is tag so -0 -1 = -1 (latest in history)
-    # dev-1 is tag+1 so -1 -1 = -2 semi lastest in history
-    return history[-offset - 1]
+    # history is HEAD -> latest_tag(included)
+    # reverse it so it tag -> HEAD
+    history = list(reversed(history))
+    # so now 0 is tag
+    #        1 is the commit after the tag
+    #        len(history) -1 is HEAD
+    try:
+        return history[offset]
+    except IndexError:
+        raise SystemExit(
+            "Unable to locate the commit that generated version: ({version})"
+        )
 
 
 def get_latest_tag(repo_path: str):

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -29,7 +29,7 @@ def get_history_since(tag: str, repo_path: str):
         [
             "git",
             "log",
-            "--pretty=format:'%H'",
+            "--pretty=format:%H",
             "--no-patch",
             f"{tag}..origin/main",
         ],

--- a/version-published/test_checkout_to_version.py
+++ b/version-published/test_checkout_to_version.py
@@ -1,0 +1,24 @@
+import unittest
+import subprocess
+from unittest.mock import patch
+
+import checkout_to_version
+
+class TestCheckoutToVersion(unittest.TestCase):
+    @patch("checkout_to_version.check_call")
+    @patch("checkout_to_version.get_revision_at_offset")
+    def test_main_happy(self, get_revision_at_offset_mock, check_call_mock):
+        checkout_to_version.main(["checkbox", "v1.2.3-dev1"])
+        self.assertTrue(get_revision_at_offset_mock.called)
+        self.assertTrue(check_call_mock.called)
+
+    @patch("checkout_to_version.check_call")
+    @patch("checkout_to_version.get_revision_at_offset")
+    def test_main_unhappy(self, get_revision_at_offset_mock, check_call_mock):
+        check_call_mock.side_effect = subprocess.CalledProcessError(1, "cmd")
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            checkout_to_version.main(["checkbox", "v1.2.3-dev1"])
+
+        self.assertTrue(get_revision_at_offset_mock.called)
+        self.assertTrue(check_call_mock.called)

--- a/version-published/test_move_branch_by_version.py
+++ b/version-published/test_move_branch_by_version.py
@@ -4,47 +4,13 @@ import move_branch_by_version
 
 
 class TestMoveBetaBranch(unittest.TestCase):
-    def test_get_offset_from_version(self):
-        version = "v1.2.3-dev45"
-
-        result = move_branch_by_version.get_offset_from_version(version)
-
-        self.assertEqual(result, 45)
-
-    @patch("move_branch_by_version.get_latest_tag")
-    @patch("move_branch_by_version.get_history_since")
-    def test_get_revision_at_offset(
-        self, mock_get_history_since, mock_get_latest_tag
-    ):
-        mock_get_latest_tag.return_value = "v1.0.0"
-        mock_get_history_since.return_value = [
-            "tag_hash + 3",
-            "tag_hash + 2",
-            "tag_hash + 1",
-            # here would be hash of tag
-        ]
-
-        result = move_branch_by_version.get_revision_at_offset(
-            "v1.2.3-dev2", "/path/to/repo"
-        )
-
-        self.assertEqual(result, "tag_hash + 2")
-
-    @patch("move_branch_by_version.get_latest_tag")
-    @patch("move_branch_by_version.get_history_since")
+    @patch("move_branch_by_version.get_revision_at_offset")
     @patch("move_branch_by_version.check_call")
-    def test_main_happy(
-        self, mock_check_call, mock_get_history_since, mock_get_latest_tag
-    ):
-        mock_get_latest_tag.return_value = "v1.0.0"
-        mock_get_history_since.return_value = [
-            "tag_hash + 3",
-            "tag_hash + 2",
-            "tag_hash + 1",
-        ]
+    def test_main_happy(self, mock_check_call, mock_get_revision_at_offset):
+        mock_get_revision_at_offset.return_value = "tag_hash + 3"
 
         move_branch_by_version.main(
-            ["/path/to/repo", "beta_validation", "v1.1.0-dev3"]
+            ["/path/to/repo", "beta", "v1.1.0-dev3"]
         )
 
         self.assertIn(
@@ -54,13 +20,8 @@ class TestMoveBetaBranch(unittest.TestCase):
             mock_check_call.call_args_list,
         )
 
-    @patch("move_branch_by_version.get_latest_tag")
-    @patch("move_branch_by_version.get_history_since")
-    @patch("move_branch_by_version.check_call")
-    def test_main_unhappy(
-        self, mock_check_call, mock_get_history_since, mock_get_latest_tag
-    ):
+    def test_main_unhappy(self):
         with self.assertRaises(SystemExit):
             move_branch_by_version.main(
-                ["/path/to/repo", "beta_validation", "v1.1.0"]
+                ["/path/to/repo", "beta", "v1.1.0"]
             )

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -22,7 +22,7 @@ class TestSnapInfoUtility(unittest.TestCase):
             "tag_hash + 3",
             "tag_hash + 2",
             "tag_hash + 1",
-            # here would be hash of tag
+            "tag_hash"
         ]
 
         result = snap_info_utility.get_revision_at_offset(

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch, call
+
+import snap_info_utility
+
+
+class TestSnapInfoUtility(unittest.TestCase):
+    def test_get_offset_from_version(self):
+        version = "v1.2.3-dev45"
+
+        result = snap_info_utility.get_offset_from_version(version)
+
+        self.assertEqual(result, 45)
+
+    @patch("snap_info_utility.get_latest_tag")
+    @patch("snap_info_utility.get_history_since")
+    def test_get_revision_at_offset(
+        self, mock_get_history_since, mock_get_latest_tag
+    ):
+        mock_get_latest_tag.return_value = "v1.0.0"
+        mock_get_history_since.return_value = [
+            "tag_hash + 3",
+            "tag_hash + 2",
+            "tag_hash + 1",
+            # here would be hash of tag
+        ]
+
+        result = snap_info_utility.get_revision_at_offset(
+            "v1.2.3-dev2", "/path/to/repo"
+        )
+
+        self.assertEqual(result, "tag_hash + 2")


### PR DESCRIPTION
The `provision_checkbox.sh` script assumes that the version that we need is tagged. We have changed this design so now it wont be the case for any beta/candidate we provision. This changes the script to support this new behaviour where we can provision any valid Checkbox version.

Examples:
```
(venv)  tmp >  ~/prj/canonical/hwcert-jenkins-tools/provision_checkbox.sh v3.3.0-dev1
[...]
++ checkbox-cli --version
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
+ echo checkbox version 3.3.1.dev1+g4114cb70c
checkbox version 3.3.1.dev1+g4114cb70c
(venv)  tmp >  ~/prj/canonical/hwcert-jenkins-tools/provision_checkbox.sh v3.3.0
[...]
++ checkbox-cli --version
$PROVIDERPATH is defined, so following provider sources are ignored ['/usr/local/share/plainbox-providers-1', '/usr/share/plainbox-providers-1', '/home/h25/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
+ echo checkbox version 3.3.0
checkbox version 3.3.0
```