### PR TITLE
Fix test observer api url and adds GH testing workflow

### DIFF
--- a/.github/workflows/test_scriptlets.yaml
+++ b/.github/workflows/test_scriptlets.yaml
@@ -1,0 +1,34 @@
+name: Test Scriptlets
+on:
+  push:
+    branches-ignore:
+      - 'main'
+    paths:
+      - 'scriptlets/**'
+      - '.github/workflows/test_scriptlets.yaml'
+# Cancel inprogress runs if new commit pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test-bash-scripts:
+    runs-on: [self-hosted, linux, large, jammy, x64]
+    defaults:
+      run:
+        working-directory: scriptlets/tests
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt install bats -y
+      - run: bats .
+  test-rerunner-script:
+    runs-on: [self-hosted, linux, large, jammy, x64]
+    defaults:
+      run:
+        working-directory: scriptlets/test-executions-rerunner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - run: pip install tox
+      - run: tox

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -14,7 +14,7 @@ from typing import Optional
 import requests
 from requests.auth import HTTPBasicAuth
 
-reruns_link = "https://test-observer.canonical.com/v1/test-executions/reruns"
+reruns_link = "https://test-observer-api.canonical.com/v1/test-executions/reruns"
 
 
 class Main:

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -14,6 +14,8 @@ from typing import Optional
 import requests
 from requests.auth import HTTPBasicAuth
 
+logging.basicConfig(level=logging.INFO)
+
 reruns_link = "https://test-observer-api.canonical.com/v1/test-executions/reruns"
 
 

--- a/scriptlets/test-executions-rerunner/tox.ini
+++ b/scriptlets/test-executions-rerunner/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4
-envlist = py38
+env_list = type, lint, py38
 
 [testenv]
 deps = 


### PR DESCRIPTION
This is a followup to last PR https://github.com/canonical/hwcert-jenkins-tools/pull/23

Turns out there was a bug with test observer api url. So this PR fixes that. I can also confirm that it's [working](http://10.102.156.15:8080/job/test-executions-rerunner/23/console).

Additionally, I've added a GH workflow to test all scriptlets as suggested https://github.com/canonical/hwcert-jenkins-tools/pull/23#discussion_r1589108408. You can confirm that it's working from here https://github.com/canonical/hwcert-jenkins-tools/actions/runs/8939122569