### PR TITLE
feat: Add downloadable installer for this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hwcert-jenkins-tools
 
-Utility scripts and tools authored by the Certification Team to enhance and automate Jenkins CI/CD pipelines.
+Utility scripts and tools authored by the Certification Team to enhance and automate CI/CD pipelines.
 
 ## provision_checkbox.sh
 
@@ -29,3 +29,21 @@ Convenience functions that help perform actions on a remote host.
 Example:
 
 * `_run reboot  # reboots the DUT`
+
+## Downloadable installer
+
+Certification jobs that need to make use of the tools in this repo can use the downloadable installer:
+
+```
+curl -Ls -o installer.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/installer.sh
+source installer.sh tools --branch LM-1580-sru-refactor
+```
+
+The installer clones this repo in a readable, consistent manner.
+It can also clone from branches, useful in cases where new tools are being developed and tested.
+
+Note that sourcing the installer script instead of executing it also defines an `add_to_path` function:
+
+```
+add_to_path tools/scriptlets
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Utility scripts and tools authored by the Certification Team to enhance and automate CI/CD pipelines.
 
+## Downloadable installer
+
+Certification jobs that need to make use of the tools in this repo can use the downloadable installer:
+
+```
+curl -Ls -o installer.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/installer.sh
+source installer.sh tools --branch LM-1580-sru-refactor
+```
+
+The installer clones this repo in a readable, consistent manner.
+It can also clone from branches, useful in cases where new tools are being developed and tested.
+
+Note that sourcing the installer script instead of executing it also defines an `add_to_path` function:
+
+```
+add_to_path tools/scriptlets
+```
+
 ## provision_checkbox.sh
 
 Tool for provisioning Checkbox from source. The provisioned Checkbox does not
@@ -30,20 +48,3 @@ Example:
 
 * `_run reboot  # reboots the DUT`
 
-## Downloadable installer
-
-Certification jobs that need to make use of the tools in this repo can use the downloadable installer:
-
-```
-curl -Ls -o installer.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/installer.sh
-source installer.sh tools --branch LM-1580-sru-refactor
-```
-
-The installer clones this repo in a readable, consistent manner.
-It can also clone from branches, useful in cases where new tools are being developed and tested.
-
-Note that sourcing the installer script instead of executing it also defines an `add_to_path` function:
-
-```
-add_to_path tools/scriptlets
-```

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Clone the certification tools repo to a local directory.
+# If the repo is already available locally, fetch the latest version.
+# Use the --branch option to specify a specific branch
+
+
+fetch() {
+    if [ "$#" -lt 1 ]; then
+        echo "Usage: ${FUNCNAME[0]} <path> [<branch>]"
+        echo "Error: You need to provide a path to a local git repo."
+        return 1
+    fi
+    local LOCAL=$1
+    local BRANCH=${2:-main}
+    git -C "$LOCAL" fetch -q --update-head-ok origin $BRANCH:$BRANCH 2> /dev/null && \
+    git -C "$LOCAL" checkout -q $BRANCH && \
+    echo "Fetched branch $BRANCH into local repo $LOCAL"
+}
+
+
+clone() {
+    if [ "$#" -lt 2 ]; then
+        echo "Usage: ${FUNCNAME[0]} <repo> <path> [<branch>]"
+        echo "Error: You need to provide a git repo and a path to clone into."
+        return 1
+    fi
+    local REPO=$1
+    local LOCAL=$2
+    local BRANCH=${3:-main}
+    git clone -q --depth=1 --branch $BRANCH $REPO $LOCAL > /dev/null && \
+    echo "Cloned $REPO\@$BRANCH into local repo $LOCAL"
+}
+
+add_to_path() {
+    if [ "$#" -lt 1 ]; then
+        echo "Error: You need to provide a path."
+        echo "Usage: ${FUNCNAME[0]} <path>"
+        return 1
+    fi
+    local PATH_TO_ADD=$(readlink -f $1)
+    if [[ ":$PATH:" != *":$PATH_TO_ADD:"* ]]; then
+        export PATH="$PATH:$PATH_TO_ADD"
+        echo "Added $PATH_TO_ADD to PATH"
+    fi
+}
+
+usage() {
+    echo "Usage: $0 [<path>] [--branch <value>]"
+    exit 1
+}
+
+# Parse command-line arguments
+TOOLS_PATH=""
+BRANCH=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --branch)
+            if [ -n "$2" ]; then
+                BRANCH=$2
+                shift
+            else
+                echo "Error: value required for --branch"
+                exit 1
+            fi
+            ;;
+        *)
+            if [ -z "$TOOLS_PATH" ]; then
+                TOOLS_PATH=$1
+            else
+                echo "Error: Invalid argument $1"
+                usage
+            fi
+            ;;
+    esac
+    shift
+done
+
+TOOLS_REPO=https://github.com/canonical/hwcert-jenkins-tools.git
+TOOLS_PATH_DEFAULT=$(basename $TOOLS_REPO .git)
+TOOLS_PATH=${TOOLS_PATH:-$TOOLS_PATH_DEFAULT}
+fetch $TOOLS_PATH $BRANCH || (rm -rf $TOOLS_PATH && clone $TOOLS_REPO $TOOLS_PATH $BRANCH)


### PR DESCRIPTION
Certification jobs that need to make use of the tools in this repo will currently explicitly clone it, often in inconsistent ways:
```
git clone --depth=1 https://github.com/canonical/hwcert-jenkins-tools.git > /dev/null
git -C hwcert-jenkins-tools pull -q || (rm -rf hwcert-jenkins-tools && git clone https://github.com/canonical/hwcert-jenkins-tools.git)
```

This PR introduces an installer that can handle cloning this repo in a readable consistent manner. It can also clone from branches, useful in cases where new tools are being developed and tested:
```
curl -Ls -o installer.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/installer.sh
source installer.sh tools --branch LM-1580-sru-refactor
```
Sourcing the script instead of executing it also defines the `add_to_path` function:
```
add_to_path tools/scriptlets
```

Here is an example of using the downloadable installer from within [a Testflinger job](https://testflinger.canonical.com/jobs/5f2b5b0f-be17-4c96-b9b6-8d7d817c0422).