### PR TITLE
Add a small delay to wait_for_snap_complete

### DIFF
--- a/scriptlets/wait_for_snap_complete
+++ b/scriptlets/wait_for_snap_complete
@@ -17,6 +17,7 @@
 
 wait_for_snap_complete_function() {
     source "$(dirname "$BASH_SOURCE")/set-ssh-options"
+    sleep 2
     set +x
     loopcnt=0
     until [ $loopcnt -gt 40 ]


### PR DESCRIPTION
This is just adding a small delay in the scriptlet to keep it consistent with the change I just made in the version of this that we use in the snap-testing templates. That way we don't lose it when we convert to using the scriptlets.