### PR TITLE
A "stacker" for Checkbox configuration files.

### DIFF
--- a/.github/workflows/test_cert_tools.yaml
+++ b/.github/workflows/test_cert_tools.yaml
@@ -1,0 +1,25 @@
+name: Test certification tools
+on:
+  push:
+    branches-ignore:
+      - 'main'
+    paths:
+      - 'cert-tools/**'
+      - '.github/workflows/test_cert_tools.yaml'
+# Cancel inprogress runs if new commit pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test-launcher-tools:
+    runs-on: [self-hosted, linux, large, jammy, x64]
+    defaults:
+      run:
+        working-directory: cert-tools/launcher
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - run: pip install .[]
+      - run: pytest

--- a/.github/workflows/test_cert_tools.yaml
+++ b/.github/workflows/test_cert_tools.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test-launcher-tools:
     name: Test certification tools
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, jammy, x64]
     defaults:
       run:
         working-directory: cert-tools/launcher

--- a/.github/workflows/test_cert_tools.yaml
+++ b/.github/workflows/test_cert_tools.yaml
@@ -6,13 +6,14 @@ on:
     paths:
       - 'cert-tools/**'
       - '.github/workflows/test_cert_tools.yaml'
-# Cancel inprogress runs if new commit pushed
 concurrency:
+  # Cancel inprogress runs if new commit pushed
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   test-launcher-tools:
-    runs-on: [self-hosted, linux, large, jammy, x64]
+    name: Test certification tools
+    runs-on: [self-hosted]
     defaults:
       run:
         working-directory: cert-tools/launcher
@@ -21,5 +22,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - run: pip install .[]
+      - run: pip install .[dev]
       - run: pytest

--- a/cert-tools/launcher/launcher/configuration.py
+++ b/cert-tools/launcher/launcher/configuration.py
@@ -1,0 +1,48 @@
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+class CheckBoxConfiguration(ConfigParser):
+
+    def __init__(self):
+        super().__init__(delimiters=("=",))
+
+    def optionxform(self, optionstr: str) -> str:
+        return str(optionstr)
+
+    @property
+    def description(self) -> Optional[str]:
+        return self.get("launcher", "session_desc", fallback=None)
+
+    @description.setter
+    def description(self, value: str):
+        if value is None:
+            return
+        try:
+            launcher_section = self["launcher"]
+        except KeyError:
+            # there is no launcher section, so it needs to be created
+            self["launcher"] = {"session_desc": value}
+        else:
+            launcher_section["session_desc"] = value
+
+    def write_to_file(self, path: Path):
+        with open(path, "w") as file:
+            self.write(file)
+
+    def stack(
+        self,
+        paths: Sequence[Path],
+        output: Path,
+        description: Optional[str] = None
+    ):
+        # stack *all* configuration files, in the specified order
+        # (read is inconvenient, it doesn't mind non-existent files)
+        for path in paths:
+            with open(path) as file:
+                self.read_file(file)
+        # add description
+        self.description = description
+        # write stacked configuration file
+        self.write_to_file(output)

--- a/cert-tools/launcher/launcher/stacker.py
+++ b/cert-tools/launcher/launcher/stacker.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+"""
+Stack a sequence of Checkbox configuration files
+
+Example:
+```
+stacker \
+--output stacked.conf \
+--description "A simple Checkbox configuration file" \
+launcher.conf manifest.conf
+```
+"""
+
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from launcher.configuration import CheckBoxConfiguration
+
+
+def parse_arguments():
+    parser = ArgumentParser(description="Stack Checkbox configuration files.")
+    parser.add_argument(
+        "config_files",
+        nargs="+",
+        type=Path,
+        help="Configuration file to be stacked"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="The resulting stacked configuration file",
+        required=True
+    )
+    parser.add_argument(
+        "--description",
+        type=str,
+        help="Description for the resulting stacked configuration file"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    CheckBoxConfiguration().stack(
+        paths=args.config_files,
+        output=args.output,
+        description=args.description
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cert-tools/launcher/pyproject.toml
+++ b/cert-tools/launcher/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "launcher"
+version = "0.1.0"
+requires-python = ">=3.8"
+
+[project.scripts]
+stacker = "launcher.stacker:main"
+
+[project.optional-dependencies]
+dev = ["pytest"]

--- a/cert-tools/launcher/tests/test_stacker.py
+++ b/cert-tools/launcher/tests/test_stacker.py
@@ -1,0 +1,160 @@
+import pytest
+
+from launcher.configuration import CheckBoxConfiguration
+
+
+def create_config_file(tmp_path, filename, content):
+    """
+    Helper function to create config files for testing.
+    """
+    path = tmp_path / filename
+    stacker = CheckBoxConfiguration()
+    stacker.read_string(content)
+    stacker.write_to_file(path)
+    return path
+
+
+@pytest.fixture
+def config_files(tmp_path):
+    """
+    Pytest fixture that creates multiple configuration files for testing.
+    """
+    configs = {
+        'config1': """
+        [section_1]
+        key_11 = value_1
+        key_12 = value_2
+        """,
+        'config2': """
+        [section_2]
+        key_21 = value_1
+        key_22 = value_2
+        """,
+        'config12': """
+        [section_1]
+        key_11 = value_3
+        [section_2]
+        key_22 = value_4
+        [launcher]
+        key_l1 = value_1
+        """,
+        'config_l': """
+        [launcher]
+        session_desc = placeholder
+        """
+    }
+    paths = {}
+    for name, content in configs.items():
+        path = create_config_file(tmp_path, name, content)
+        paths[name] = path
+        with open(path) as file:
+            contents = file.read()
+            print(path)
+            print(contents)
+    return paths
+
+
+def test_stack_invalid_filename(config_files):
+    """
+    Non-existent files should raise a `FileNotFoundError`
+    """
+    with pytest.raises(FileNotFoundError):
+        CheckBoxConfiguration().stack(
+            paths=['nonexistent', config_files['config1']],
+            output='stacked.conf'
+        )
+
+
+def test_stack_no_overlap(config_files):
+    """
+    Stack non-overlapping configurations
+    """
+    CheckBoxConfiguration().stack(
+        paths=[
+            config_files['config1'],
+            config_files['config2']
+        ],
+        output='stacked.conf'
+    )
+
+    stacked = CheckBoxConfiguration()
+    stacked.read('stacked.conf')
+
+    assert stacked['section_1']['key_11'] == 'value_1'
+    assert stacked['section_2']['key_22'] == 'value_2'
+
+
+def test_stack_overlap(config_files):
+    """
+    Stack overlapping configurations and check overrides
+    """
+    CheckBoxConfiguration().stack(
+        paths=[
+            config_files['config1'],
+            config_files['config12'],
+            config_files['config2']
+        ],
+        output='stacked.conf'
+    )
+
+    stacked = CheckBoxConfiguration()
+    stacked.read('stacked.conf')
+
+    # config_12 overrides section_1 -> key_11 from config_1
+    assert stacked['section_1']['key_11'] == 'value_3'
+    # config_2 overrides section_1 -> key_11 from config_12
+    assert stacked['section_2']['key_22'] == 'value_2'
+
+
+def test_description_without_launcher(config_files):
+    """
+    Add a description that creates a `launcher` section
+    """
+    CheckBoxConfiguration().stack(
+        paths=[
+            config_files['config1'],
+        ],
+        output='stacked.conf',
+        description="description"
+    )
+
+    stacked = CheckBoxConfiguration()
+    stacked.read('stacked.conf')
+
+    assert stacked['launcher']['session_desc'] == "description"
+
+
+def test_description_with_launcher(config_files):
+    """
+    Add a description into an existing `launcher` section
+    """
+    CheckBoxConfiguration().stack(
+        paths=[
+            config_files['config12'],
+        ],
+        output='stacked.conf',
+        description="description"
+    )
+
+    stacked = CheckBoxConfiguration()
+    stacked.read('stacked.conf')
+
+    assert stacked['launcher']['session_desc'] == "description"
+
+
+def test_description_with_description(config_files):
+    """
+    Add a description over an existing one
+    """
+    CheckBoxConfiguration().stack(
+        paths=[
+            config_files['config_l'],
+        ],
+        output='stacked.conf',
+        description="description"
+    )
+
+    stacked = CheckBoxConfiguration()
+    stacked.read('stacked.conf')
+
+    assert stacked['launcher']['session_desc'] == "description"


### PR DESCRIPTION
# Description

Certification tasks need to assemble several Checkbox configuration files (e.g. a common "head", a test plan, a manifest, environment variables) into a single file, also adding a description to it.

This is currently accomplished using a [series of calls to inline Python scripts](https://github.com/canonical/hwcert-jenkins-jobs/blob/e81967505b34fec0bc7087024cb08e8ac4c59b7f/jobs/snap-testing/run-checkbox-snappy.sh#L337) that are not readable, maintainable or extensible.

This PR introduces a purpose-built Python tool for this kind of functionality, called `stacker`, complete with tests and a CI workflow that triggers them. The tool will eventually become part of a larger suite that assembles Checkbox configuration files (the interested reader can refer to the outputs of the [CR062 spike](https://github.com/canonical/hwcert-jenkins-jobs/tree/CR062-investigation/tools/launchers)).

# Testing

- Using the stacker [within a Testflinger job](https://testflinger.canonical.com/jobs/f2e67413-ec24-48d0-a464-5b5c58165469) 
- CI testing [workflow running the stacker tests](https://github.com/canonical/hwcert-jenkins-tools/actions/runs/9446750299/job/26017066806)
