### PR TITLE
[LM-1596] fix: corrections to `add_private_ppa.py`

### DIFF
--- a/add_private_ppa.py
+++ b/add_private_ppa.py
@@ -18,6 +18,7 @@ Finally, the PPA's key is added to the system.
 import argparse
 import logging
 import os
+import re
 import subprocess
 import textwrap
 from typing import List
@@ -93,18 +94,7 @@ def slugify_name(name: str) -> str:
     >>> slugify_name(r"a/b\\:*?\\"<>| ")
     'a-b----------'
     """
-    return (
-        name.replace("/", "-")
-        .replace("\\", "-")
-        .replace(":", "-")
-        .replace("*", "-")
-        .replace("?", "-")
-        .replace('"', "-")
-        .replace("<", "-")
-        .replace(">", "-")
-        .replace("|", "-")
-        .replace(" ", "-")
-    )
+    return re.sub(r'[\/\\:*?"<>| ]', '-', name)
 
 
 def create_apt_auth_file(ppa: str, login: str, password: str) -> None:

--- a/add_private_ppa.py
+++ b/add_private_ppa.py
@@ -20,13 +20,14 @@ import logging
 import os
 import subprocess
 import textwrap
+from typing import List
 from urllib.parse import urlparse
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger().name = os.path.basename(__file__)
 
 
-def neatly_run_command(cmd: list[str]) -> str:
+def neatly_run_command(cmd: List[str]) -> str:
     """
     This command tries to run command and if the command fails it will log the
     error and exit the program.

--- a/add_private_ppa.py
+++ b/add_private_ppa.py
@@ -112,7 +112,7 @@ def create_apt_auth_file(ppa: str, login: str, password: str) -> None:
         login {}
         password {}
         """
-    ).format(host, login, password)
+    ).format(f"{host}/{path}", login, password)
 
     auth_file_path = "/etc/apt/auth.conf.d/ppa-{}.conf".format(ppa_name)
     if os.path.exists(auth_file_path):


### PR DESCRIPTION
# Description

This PR resolves two issues that prevented `add_private_ppa` from working properly in the context of [LM-1596](https://warthogs.atlassian.net/browse/LM-1596).

## Backwards compatibility

An exception is raised when the `add_private_ppa.py` script is used on a device with an older version of Python that doesn't support type annotations on lists. This PR uses `typing.List` instead to overcome the problem.

The current and newer versions were tested on a `bionic` multipass container. The current version demonstrates the issue:
```
Traceback (most recent call last):
  File "./add_private_ppa.py", line 29, in <module>
    def neatly_run_command(cmd: list[str]) -> str:
TypeError: 'type' object is not subscriptable
```
The newer version resolves it:
```
$ sudo ./add_private_ppa.py $PPA $USERNAME $PASSWORD $KEY 
INFO:add_private_ppa.py:Created credentials file: /etc/apt/auth.conf.d/***.conf
Warning: apt-key output should not be parsed (stdout is not a terminal)
gpg: key 28904F735516A5D3: public key "***" imported
gpg: Total number processed: 1
gpg:               imported: 1
INFO:add_private_ppa.py:Guessing Ubuntu codename...
INFO:add_private_ppa.py:Ubuntu codename guessed: bionic
INFO:add_private_ppa.py:Created sources list file: /etc/apt/sources.list.d/***.list
```

## Auth file

The current version of `add_private_ppa` inserts the entire PPA URL into the `machine` field of the file created in `etc/apt/auth.conf.d/`. This includes the protocol at the beginning of the URL. While this is [acceptable in newer versions of Ubuntu](https://manpages.ubuntu.com/manpages/focal/man5/apt_auth.conf.5.html), the protocol [should not be provided in `bionic`](https://manpages.ubuntu.com/manpages/bionic/man5/apt_auth.conf.5.html). 

The current and newer versions were tested on a `bionic` multipass container. The current version demonstrates the issue:
```
$ sudo apt-get update
Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease                                                                
Hit:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease                                                        
Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease                                                  
Err:5 *** bionic InRelease              
  401  Unauthorized [IP: ***]
Reading package lists... Done                     
E: Failed to fetch ***  401  Unauthorized [IP: ***]
E: The repository '***' is no longer signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
The newer version resolves it:
```
$ sudo apt-get update
Hit:1 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease                                                            
Hit:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease                                                    
Hit:4 http://archive.ubuntu.com/ubuntu bionic-backports InRelease                                                  
Get:5 *** bionic InRelease [15.9 kB]    
Get:6 *** Sources [21.4 kB]
Get:7 *** amd64 Packages [107 kB]
Get:8 *** Translation-en [28.6 kB]
Fetched 173 kB in 4s (38.8 kB/s) 
Reading package lists... Done
```

## Minor improvement

As an aside, an additional commit is also included to shorten the way slugification is performed, using the `re` package.

[LM-1596]: https://warthogs.atlassian.net/browse/LM-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ