### PR TITLE
Script to get failing services from submissions (New)

### DIFF
--- a/submissions-tools/.gitignore
+++ b/submissions-tools/.gitignore
@@ -1,0 +1,3 @@
+submissions/
+submissions.txt
+**failing_services.csv

--- a/submissions-tools/.gitignore
+++ b/submissions-tools/.gitignore
@@ -1,3 +1,3 @@
 submissions/
 submissions.txt
-**failing_services.csv
+failing_services_*.csv

--- a/submissions-tools/README.md
+++ b/submissions-tools/README.md
@@ -30,6 +30,13 @@ C3 API.
 
 ## Usage
 
+## Prerequisites
+
+You will need a session ID to authenticate with the certification website. You
+can obtain this by logging into the certification website, opening 
+[your profile](https://certification.canonical.com/me/), and copying the value
+of the `Session ID`.   
+
 ### Downloading Submissions
 
 1. Prepare a text file containing the URLs of the submissions you wish to
@@ -66,10 +73,3 @@ https://certification.canonical.com/hardware/202212-30927/submission/371010/
 
 3. The script will download the submissions, analyze the test output files, and
    generate a CSV file listing the failing services. 
-
-
-## Contributing
-
-Contributions to improve these tools are welcome. If you have an idea for a new
-script or an improvement to an existing one, please open an issue or submit a
-pull request.

--- a/submissions-tools/README.md
+++ b/submissions-tools/README.md
@@ -3,7 +3,7 @@
 This folder contains some tools designed to interact with the certification
 website, specifically for downloading submissions and analyzing them.
 
-These script can be really useful when trying to investigate a test failure in 
+These scripts can be really useful when trying to investigate a test failure in 
 a large set of devices, since it allows you to automate the process of going
 through the submission files and manually check the results.
 
@@ -30,7 +30,7 @@ C3 API.
 
 ## Usage
 
-## Prerequisites
+### Prerequisites
 
 You will need a session ID to authenticate with the certification website. You
 can obtain this by logging into the certification website, opening 
@@ -56,7 +56,7 @@ https://certification.canonical.com/hardware/202212-30927/submission/371010/
 ```
 
 3. The script will download the submissions and save them in a local directory
-   structure.
+   structure. Submissions that have already been downloaded will be skipped.
 
 ### Analyzing Failing Services
 

--- a/submissions-tools/README.md
+++ b/submissions-tools/README.md
@@ -1,0 +1,75 @@
+# Submission Tools
+
+This folder contains some tools designed to interact with the certification
+website, specifically for downloading submissions and analyzing them.
+
+These script can be really useful when trying to investigate a test failure in 
+a large set of devices, since it allows you to automate the process of going
+through the submission files and manually check the results.
+
+The tools only include for now the script to analyze the services that failed
+to start post-reboot, but more scripts can be added in the future to automate
+other analysis tasks.
+
+One of the steps is to get the set of URLs of the submissions you want to
+review. At the current moment, the easiest way to get this list is using the
+filters on the corresponding SRU review document (e.g. [SRU Review#4](https://docs.google.com/spreadsheets/d/1m-YrtOiGH8XM5dZY9n6UcNeY-sJebyNUQar053VvBb0/edit?gid=1644139636#gid=1644139636)),
+but this may be easier in the future if this functionality is implemented in the
+C3 API.
+
+## Overview
+
+- **download_submissions.py**: Downloads a list of submissions from the
+   certification website. It reads submission URLs from a provided file,
+   downloads the submissions, and saves them locally for further analysis.
+
+- **get_failing_services.py**: Downloads and analyzes a list of submissions.
+   Then, uses the test output files to identify any services that failed to
+   start post-reboot. It supports analyzing results from both warm and cold
+   reboots.
+
+## Usage
+
+### Downloading Submissions
+
+1. Prepare a text file containing the URLs of the submissions you wish to
+   download, one URL per line.
+
+```
+https://certification.canonical.com/hardware/202212-31030/submission/370807/
+https://certification.canonical.com/hardware/202301-31145/submission/371588/
+https://certification.canonical.com/hardware/202212-30927/submission/371010/
+```
+
+2. Run the `download_submissions.py` script, providing the path to your text
+   file and your session ID:
+
+```sh
+./download_submissions.py submissions_file.txt --session-id YOUR_SESSION_ID
+```
+
+3. The script will download the submissions and save them in a local directory
+   structure.
+
+### Analyzing Failing Services
+
+1. Prepare a text file containing the URLs of the submissions you wish to
+   download, one URL per line.
+
+2. Run the `get_failing_services.py` script, providing the same submissions file
+   and session ID. Optionally, specify if you want to analyze the results of a
+   warm or cold reboot:
+
+```sh
+./get_failing_services.py submissions_file.txt --session-id YOUR_SESSION_ID --test post-warm-reboot
+```
+
+3. The script will download the submissions, analyze the test output files, and
+   generate a CSV file listing the failing services. 
+
+
+## Contributing
+
+Contributions to improve these tools are welcome. If you have an idea for a new
+script or an improvement to an existing one, please open an issue or submit a
+pull request.

--- a/submissions-tools/download_submissions.py
+++ b/submissions-tools/download_submissions.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 Canonical Ltd.
+# Written by:
+#   Fernando Bravo <fernando.bravo.hernandez@canonical.com>
+
+"""
+Tools to download a list of submissions from the certification website.
+
+Example of a submission URL:
+https://certification.canonical.com/hardware/202309-32084/submission/360899/
+"""
+
+import argparse
+from requests import get
+import os
+import pathlib
+import pandas as pd
+import tarfile
+import tempfile
+
+
+SESSION_ID = ""
+
+
+def get_submissions_list(file):
+    """
+    Read the submission urls from a file line by line
+
+    :param file: path to the file containing the submission URLs
+    :return: a list of dictionaries with the submission information
+    """
+
+    # Read the submission urls from a file line by line
+    with open(file, "r") as f:
+        # Read the lines, ignoring the new line character
+        lines = f.read().splitlines()
+
+    submissions = []
+    for line in lines:
+        # Ignore lines starting with #
+        if line.startswith("#"):
+            continue
+        # Remove the trailing slash
+        url = line.rstrip("/")
+        # Get the submission ID
+        id = url.split("/")[-1]
+        # Get the device ID
+        device_id = url.split("/")[-3]
+
+        submissions.append({"id": id, "device_id": device_id, "url": url})
+
+    return submissions
+
+
+def download_submissions(submission, session_id):
+    id = submission["id"]
+    url = submission["url"]
+
+    path = pathlib.Path(f"submissions/{id}")
+
+    # Check if the session ID is set
+    if not session_id:
+        raise SystemExit("Session ID is required to download the submissions.")
+
+    # Create the submissions folder if it does not exist
+    if not path.exists():
+        pathlib.Path("submissions").mkdir(parents=True, exist_ok=True)
+
+    # Check if the submission already exists
+    if os.path.exists(path):
+        print(f"File already exists: {path}")
+        return
+
+    # Get the content of the URL
+    tokens = {"sessionid": session_id}
+    response = get(f"{url}/data", cookies=tokens)
+    if response.status_code == 200:
+        # Find if the authentication failed looking at the content for
+        # the string "OpenID transaction in progress"
+        if "OpenID transaction in progress" in response.text:
+            print(response.text)
+            raise SystemExit("Authentication failed.")
+        print(f"Submission downloaded successfully: {id}")
+    else:
+        raise SystemExit("Failed to download the file.")
+
+    # Write the content to a temporary file
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as file:
+        file.write(response.content)
+
+        # Decompress the file using the tarfile module
+        with tarfile.open(file.name, "r") as tar:
+            tar.extractall(path=path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download a list of submissions from C3."
+    )
+    parser.add_argument(
+        "submissions_file",
+        help="File containing the submission URLs",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="Session ID to authenticate with the certification website. "
+        "It can be obtained in the developer section of your profile in C3",
+        default="",
+    )
+    args = parser.parse_args()
+
+    submissions = get_submissions_list(args.submissions_file)
+    for submission in submissions:
+        download_submissions(submission, args.session_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions-tools/download_submissions.py
+++ b/submissions-tools/download_submissions.py
@@ -15,7 +15,6 @@ import argparse
 from requests import get
 import os
 import pathlib
-import pandas as pd
 import tarfile
 import tempfile
 

--- a/submissions-tools/get_failing_services.py
+++ b/submissions-tools/get_failing_services.py
@@ -7,6 +7,7 @@
 # https://certification.canonical.com/hardware/202312-33291/submission/360841/
 
 import argparse
+import csv
 import os
 import pathlib
 
@@ -54,13 +55,13 @@ def get_failing_services_post_reboot(submissions, test="post-warm-reboot"):
                     failing_services.append(row)
 
         # Create a CSV file with the failing services
-        with open(f"failing_services_{test}.csv", "w") as file:
-            file.write("device_id,submission_id,service\n")
-            for row in failing_services:
-                device_id = row["device_id"]
-                submission_id = row["submission_id"]
-                service = row["service"]
-                file.write(f"{device_id},{submission_id},{service}\n")
+        with open(f"failing_services_{test}.csv", "w") as csv_file:
+            fieldnames = ["device_id", "submission_id", "service"]
+
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+
+            writer.writeheader()
+            writer.writerows(failing_services)
 
 
 def main():

--- a/submissions-tools/get_failing_services.py
+++ b/submissions-tools/get_failing_services.py
@@ -8,7 +8,6 @@
 
 import argparse
 import os
-import pandas as pd
 import pathlib
 
 from download_submissions import get_submissions_list, download_submissions
@@ -54,10 +53,14 @@ def get_failing_services_post_reboot(submissions, test="post-warm-reboot"):
 
                     failing_services.append(row)
 
-        # Create a dataframe to store the failing services
-        df = pd.DataFrame(failing_services)
-        csv_path = pathlib.Path(f"{test}_failing_services.csv")
-        df.to_csv(csv_path, index=False)
+        # Create a CSV file with the failing services
+        with open(f"failing_services_{test}.csv", "w") as file:
+            file.write("device_id,submission_id,service\n")
+            for row in failing_services:
+                device_id = row["device_id"]
+                submission_id = row["submission_id"]
+                service = row["service"]
+                file.write(f"{device_id},{submission_id},{service}\n")
 
 
 def main():

--- a/submissions-tools/get_failing_services.py
+++ b/submissions-tools/get_failing_services.py
@@ -1,0 +1,95 @@
+# Example of the data in the file
+# Submission Report URL
+# https://certification.canonical.com/hardware/202309-32084/submission/360899/
+# https://certification.canonical.com/hardware/202310-32275/submission/360894/
+# https://certification.canonical.com/hardware/202401-33353/submission/360849/
+# https://certification.canonical.com/hardware/202309-32040/submission/360844/
+# https://certification.canonical.com/hardware/202312-33291/submission/360841/
+
+import argparse
+import os
+import pandas as pd
+import pathlib
+
+from download_submissions import get_submissions_list, download_submissions
+
+
+def get_failing_services_post_reboot(submissions, test="post-warm-reboot"):
+    """
+    Get the failing services from the test output file
+
+    :param submissions: list of submissions
+    :param test: name of the test
+    :return: list of failing services
+    """
+
+    # Create a list to store the failing services
+    failing_services = []
+    for submission in submissions:
+        id = submission["id"]
+        test_name = f"com.canonical.certification__power-management_{test}"
+        path = pathlib.Path(f"submissions/{id}/test_output/{test_name}")
+
+        # Check if the file exists
+        if not os.path.exists(path):
+            print(f"File {path} does not exist")
+            continue
+
+        # Read the content of the file and check the failing services
+        with open(path, "r") as file:
+            content = file.read()
+            # Find the lines starting with "●"  and get the service name
+            # Example:
+            # ● casper-md5check.service loaded failed failed casper-md5check Verify Live ISO checksums
+            for line in content.splitlines():
+                if line.startswith("●"):
+                    service_name = line.split()[1]
+
+                    # dictionary to store the failing services
+                    row = {
+                        "device_id": submission["device_id"],
+                        "submission_id": id,
+                        "service": service_name,
+                    }
+
+                    failing_services.append(row)
+
+        # Create a dataframe to store the failing services
+        df = pd.DataFrame(failing_services)
+        csv_path = pathlib.Path(f"{test}_failing_services.csv")
+        df.to_csv(csv_path, index=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download a list of submissions from C3."
+    )
+    parser.add_argument(
+        "submissions_file",
+        help="File containing the submission URLs",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="Session ID to authenticate with the certification website. "
+        "It can be obtained in the developer section of your profile in C3",
+        default="",
+    )
+    # Choose between post-warm-reboot and post-cold-reboot
+    parser.add_argument(
+        "--test",
+        default="post-warm-reboot",
+        help="Test to get the failing services",
+        choices=["post-warm-reboot", "post-cold-reboot"],
+    )
+
+    args = parser.parse_args()
+
+    submissions = get_submissions_list(args.submissions_file)
+    for submission in submissions:
+        download_submissions(submission, args.session_id)
+
+    get_failing_services_post_reboot(submissions, args.test)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

One of the most failed tests on the last SRU review was the power-management/post-warm-reboot test. These tests are failing because there are some services on some devices that are failing.
We want to get some more information about the tests that are failing, so we can in the future fix the most recurrent ones.

## Resolves

https://warthogs.atlassian.net/browse/CHECKBOX-1467

## Test

1. Create a `submissions.txt` file with the submissions you want to analyze:
```
https://certification.canonical.com/hardware/202212-31030/submission/370807/
https://certification.canonical.com/hardware/202301-31145/submission/371588/
https://certification.canonical.com/hardware/202212-30927/submission/371010/
```
2. Get your Session Id from your C3 profile under the Developer section
3. Run the script
```
python get_failing_services.py submissions.txt --session-id <YOUR_ID> --test post-warm-reboot
``` 