### PR TITLE
Snap info fixed version (BugFix)

### DIFF
--- a/.github/workflows/test_version_published.yaml
+++ b/.github/workflows/test_version_published.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox -e py310
+        run: tox -e py38

--- a/.github/workflows/test_version_published.yaml
+++ b/.github/workflows/test_version_published.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install tox
         run: pip install tox
       - name: Run tox

--- a/.github/workflows/test_version_published.yaml
+++ b/.github/workflows/test_version_published.yaml
@@ -1,0 +1,29 @@
+name: Test published version tools
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'version-published/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'version-published/**'
+      - '.github/workflows/test_version_published.yaml'
+
+jobs:
+  tox_test_version_published:
+    name: Test version-published with tox
+    defaults:
+      run:
+        working-directory: version-published
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install tox
+        run: pip install tox
+      - name: Run tox
+        run: tox -e py310

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -6,7 +6,11 @@ scripts that fetches information about snaps
 import re
 import requests
 
-from packaging import version
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version
+
 from subprocess import check_output
 
 
@@ -71,7 +75,7 @@ def get_previous_tag(base_version: str, repo_path: str):
     # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
     previous_tag = None
     for t in tags:
-        if version.parse(t) < version.parse(base_version):
+        if Version(t) < Version(base_version):
             previous_tag = t
             break
 

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -2,7 +2,11 @@
 This module contains every utility function shared among multiple
 scripts that fetches information about snaps
 """
+
+import re
 import requests
+
+from packaging import version
 from subprocess import check_output
 
 
@@ -38,16 +42,57 @@ def get_history_since(tag: str, repo_path: str):
     ).splitlines()
 
 
-def get_offset_from_version(version: str) -> int:
-    if "dev" not in version:
-        return 0
-    return int(version.rsplit("dev", 1)[1])
+def get_version_and_offset(version_str: str):
+    # Use regex to match the version pattern and extract the base version
+    # and dev number if present (e.g. v1.2.3-dev45, 1.2.3.dev45, 1.2.3)
+    # the v at the beginning is optional
+    match = re.match(r"^v?(\d+\.\d+\.\d+).?(?:dev(\d+))?$", version_str)
+    if match:
+        base_version = f"v{match.group(1)}"
+        dev_number = match.group(2) if match.group(2) else "0"
+        return base_version, int(dev_number)
+    else:
+        raise ValueError(f"Invalid version format: {version_str}")
 
 
-def get_revision_at_offset(version: str, repo_path: str):
-    tag = get_latest_tag(repo_path)
-    history = get_history_since(tag, repo_path)
-    offset = get_offset_from_version(version)
+def get_previous_tag(base_version: str, repo_path: str):
+    # Get the list of tags sorted by creation date
+    tags = check_output(
+        ["git", "tag", "--sort=-creatordate"], cwd=repo_path, text=True
+    ).splitlines()
+
+    # Filter the list of tags to only include the ones that match the version
+    # pattern
+    tags = [tag for tag in tags if re.match(r"^v\d+\.\d+\.\d+$", tag)]
+    print(tags)
+
+    # Get the previous tag corresponding to the base version. We have to do it
+    # this way because the tags are only created once the version is published.
+    # For example, 4.0.0.dev333 will use the previous tag v3.3.0 to calculate
+    # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
+    previous_tag = None
+    for t in tags:
+        print(f"Comparing {t} with {base_version}")
+        if version.parse(t) < version.parse(base_version):
+            print(f"Found previous tag: {t}")
+            previous_tag = t
+            break
+
+    if not previous_tag:
+        raise SystemExit(
+            f"Unable to locate a previous tag for the version: {base_version}"
+        )
+
+    return previous_tag
+
+
+def get_revision_at_offset(version_str: str, repo_path: str):
+    base_version, offset = get_version_and_offset(version_str)
+    previous_tag = get_previous_tag(base_version, repo_path)
+    history = get_history_since(previous_tag, repo_path)
+    print(
+        f"Checkout to {offset} commits after the preceding tag {previous_tag}"
+    )
     # history is HEAD -> latest_tag(included)
     # reverse it so it tag -> HEAD
     history = list(reversed(history))
@@ -58,11 +103,5 @@ def get_revision_at_offset(version: str, repo_path: str):
         return history[offset]
     except IndexError:
         raise SystemExit(
-            "Unable to locate the commit that generated version: ({version})"
+            f"Unable to locate the commit that generated version: {version_str}"
         )
-
-
-def get_latest_tag(repo_path: str):
-    return check_output(
-        ["git", "describe", "--tags", "--abbrev=0"], cwd=repo_path, text=True
-    ).strip()

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -84,21 +84,12 @@ def get_previous_tag(base_version: str, repo_path: str):
     # this way because the tags are only created once the version is published.
     # For example, 4.0.0.dev333 will use the previous tag v3.3.0 to calculate
     # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
-    previous_tag = None
-    for t in tags:
-        try:
-            if Version(t) < Version(base_version):
-                previous_tag = t
-                break
-        except ValueError:
-            print(f"Invalid version tag: {t}")
-
-    if not previous_tag:
+    try:
+        return next(t for t in tags if Version(t) < Version(base_version))
+    except StopIteration:
         raise SystemExit(
             f"Unable to locate a previous tag for the version: {base_version}"
         )
-
-    return previous_tag
 
 
 def get_revision_at_offset(version_str: str, repo_path: str):

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -64,7 +64,6 @@ def get_previous_tag(base_version: str, repo_path: str):
     # Filter the list of tags to only include the ones that match the version
     # pattern
     tags = [tag for tag in tags if re.match(r"^v\d+\.\d+\.\d+$", tag)]
-    print(tags)
 
     # Get the previous tag corresponding to the base version. We have to do it
     # this way because the tags are only created once the version is published.
@@ -72,9 +71,7 @@ def get_previous_tag(base_version: str, repo_path: str):
     # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
     previous_tag = None
     for t in tags:
-        print(f"Comparing {t} with {base_version}")
         if version.parse(t) < version.parse(base_version):
-            print(f"Found previous tag: {t}")
             previous_tag = t
             break
 

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -10,25 +10,26 @@ class TestSnapInfoUtility(unittest.TestCase):
     def test_get_version_and_offset(self):
         version = "v1.2.3-dev45"
         b_version, offset = snap_info_utility.get_version_and_offset(version)
-        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(b_version, "1.2.3")
         self.assertEqual(offset, 45)
 
         version = "1.2.3"
         b_version, offset = snap_info_utility.get_version_and_offset(version)
-        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(b_version, "1.2.3")
         self.assertEqual(offset, 0)
 
         version = "1.2.3.dev45"
         b_version, offset = snap_info_utility.get_version_and_offset(version)
-        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(b_version, "1.2.3")
         self.assertEqual(offset, 45)
 
         version = "v1.2"
-        with self.assertRaises(ValueError):
-            snap_info_utility.get_version_and_offset(version)
+        b_version, offset = snap_info_utility.get_version_and_offset(version)
+        self.assertEqual(b_version, "1.2")
+        self.assertEqual(offset, 0)
 
         version = "1.2.3-dv25"
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SystemExit):
             snap_info_utility.get_version_and_offset(version)
 
     @patch("snap_info_utility.check_output")

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -1,28 +1,65 @@
 import unittest
 from unittest.mock import patch, call
 
+import textwrap
+
 import snap_info_utility
 
 
 class TestSnapInfoUtility(unittest.TestCase):
-    def test_get_offset_from_version(self):
+    def test_get_version_and_offset(self):
         version = "v1.2.3-dev45"
+        b_version, offset = snap_info_utility.get_version_and_offset(version)
+        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(offset, 45)
 
-        result = snap_info_utility.get_offset_from_version(version)
+        version = "1.2.3"
+        b_version, offset = snap_info_utility.get_version_and_offset(version)
+        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(offset, 0)
 
-        self.assertEqual(result, 45)
+        version = "1.2.3.dev45"
+        b_version, offset = snap_info_utility.get_version_and_offset(version)
+        self.assertEqual(b_version, "v1.2.3")
+        self.assertEqual(offset, 45)
 
-    @patch("snap_info_utility.get_latest_tag")
+        version = "v1.2"
+        with self.assertRaises(ValueError):
+            snap_info_utility.get_version_and_offset(version)
+
+        version = "1.2.3-dv25"
+        with self.assertRaises(ValueError):
+            snap_info_utility.get_version_and_offset(version)
+
+    @patch("snap_info_utility.check_output")
+    def test_get_previous_tag(self, mock_check_output):
+        mock_check_output.return_value = textwrap.dedent(
+            """
+            v1.2.3
+            v1.2.2
+            v1.2.1
+            """
+        )
+        result = snap_info_utility.get_previous_tag("v1.2.3", "/path/to/repo")
+        self.assertEqual(result, "v1.2.2")
+
+        result = snap_info_utility.get_previous_tag("v1.2.2", "/path/to/repo")
+        self.assertEqual(result, "v1.2.1")
+
+        with self.assertRaises(SystemExit):
+            snap_info_utility.get_previous_tag("v1.0.0", "/path/to/repo")
+
+    @patch("snap_info_utility.get_previous_tag")
     @patch("snap_info_utility.get_history_since")
     def test_get_revision_at_offset(
-        self, mock_get_history_since, mock_get_latest_tag
+        self, mock_get_history_since, mock_get_previous_tag
     ):
-        mock_get_latest_tag.return_value = "v1.0.0"
+        mock_get_previous_tag.return_value = "v1.0.0"
         mock_get_history_since.return_value = [
             "tag_hash + 3",
             "tag_hash + 2",
             "tag_hash + 1",
-            "tag_hash"
+            "tag_hash",
         ]
 
         result = snap_info_utility.get_revision_at_offset(
@@ -30,3 +67,21 @@ class TestSnapInfoUtility(unittest.TestCase):
         )
 
         self.assertEqual(result, "tag_hash + 2")
+
+    @patch("snap_info_utility.get_previous_tag")
+    @patch("snap_info_utility.get_history_since")
+    def test_get_revision_at_offset_error(
+        self, mock_get_history_since, mock_get_previous_tag
+    ):
+        mock_get_previous_tag.return_value = "v1.0.0"
+        mock_get_history_since.return_value = [
+            "tag_hash + 3",
+            "tag_hash + 2",
+            "tag_hash + 1",
+            "tag_hash",
+        ]
+
+        with self.assertRaises(SystemExit):
+            snap_info_utility.get_revision_at_offset(
+                "v1.2.3-dev5", "/path/to/repo"
+            )

--- a/version-published/tox.ini
+++ b/version-published/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310
+envlist = py38
 skip_missing_interpreters = true
 isolated_build = True
 
@@ -10,12 +10,13 @@ commands =
     {envpython} -m coverage xml
 
 
-[testenv:py310]
+[testenv:py38]
 deps =
     pytest
     coverage == 7.3.0
     requests == 2.25.1
     PyYAML == 6.0.1
+
 
 [pytest]
 python_files = test_*.py

--- a/version-published/tox.ini
+++ b/version-published/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py310
+skip_missing_interpreters = true
+isolated_build = True
+
+[testenv]
+commands =
+    {envpython} -m coverage run -m pytest .
+    {envpython} -m coverage report
+    {envpython} -m coverage xml
+
+
+[testenv:py310]
+deps =
+    pytest
+    coverage == 7.3.0
+    requests == 2.25.1
+    PyYAML == 6.0.1
+
+[pytest]
+python_files = test_*.py
+


### PR DESCRIPTION
## Description
There was a bug with the checkout_to_version.ty tool in which the wrong version was fetched and no debug information was shown. 
```
12:19:34 + hwcert-jenkins-tools/version-published/checkout_to_version.py /home/ubuntu/checkbox 4.0.0.dev333
12:19:34 Unable to locate the commit that generated version: ({version})
```

Some people fixed it setting the branch manually, but this fix should solve the issue. 
![image](https://github.com/user-attachments/assets/d6b02ef6-2f29-41c3-b2db-7efe70013e1d)

This new version should work as intended and outputs some useful debug information:
```
python version-published/checkout_to_version.py /home/ubuntu/checkbox 4.0.0~dev333
Checkout to 333 commits after the preceding tag v3.3.0
M       .gitignore
HEAD is now at be9508960 [checkbox-ce-oem] Remove manifest from resource job (BugFix) (#1316)
```
