### PR TITLE
fixed bug with snap info version (BugFix)

### DIFF
--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -65,6 +65,7 @@ def get_version_and_offset(version_str: str):
     # Try to parse the version and dev number
     try:
         Version(base_version)
+        dev_number = int(dev_number)
     except ValueError:
         raise SystemExit(f"Invalid version format: {version_str}")
 
@@ -78,14 +79,16 @@ def get_previous_tag(base_version: str, repo_path: str):
     ).splitlines()
 
     # Filter the list of tags to only include the ones that start with 'v'
-    tags = [t for t in tags if t.startswith("v")]
+    tags = [t[1:] for t in tags if t.startswith("v")]
 
     # Get the previous tag corresponding to the base version. We have to do it
     # this way because the tags are only created once the version is published.
     # For example, 4.0.0.dev333 will use the previous tag v3.3.0 to calculate
     # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
     try:
-        return next(t for t in tags if Version(t) < Version(base_version))
+        return next(
+            f"v{t}" for t in tags if Version(t) < Version(base_version)
+        )
     except StopIteration:
         raise SystemExit(
             f"Unable to locate a previous tag for the version: {base_version}"

--- a/version-published/snap_info_utility.py
+++ b/version-published/snap_info_utility.py
@@ -72,23 +72,28 @@ def get_version_and_offset(version_str: str):
     return base_version, int(dev_number)
 
 
-def get_previous_tag(base_version: str, repo_path: str):
+def get_list_of_tags(repo_path: str):
     # Get the list of tags sorted by creation date
     tags = check_output(
         ["git", "tag", "--sort=-creatordate"], cwd=repo_path, text=True
     ).splitlines()
 
     # Filter the list of tags to only include the ones that start with 'v'
-    tags = [t[1:] for t in tags if t.startswith("v")]
+    tags = [t for t in tags if t.startswith("v")]
 
+    if not tags:
+        raise SystemExit("No tags found in the repository")
+
+    return tags
+
+
+def get_previous_tag(base_version: str, tags: list):
     # Get the previous tag corresponding to the base version. We have to do it
     # this way because the tags are only created once the version is published.
     # For example, 4.0.0.dev333 will use the previous tag v3.3.0 to calculate
     # the offset, not v4.0.0. The versions after 4.0.0 will use v4.0.0.
     try:
-        return next(
-            f"v{t}" for t in tags if Version(t) < Version(base_version)
-        )
+        return next(t for t in tags if Version(t[1:]) < Version(base_version))
     except StopIteration:
         raise SystemExit(
             f"Unable to locate a previous tag for the version: {base_version}"
@@ -97,7 +102,8 @@ def get_previous_tag(base_version: str, repo_path: str):
 
 def get_revision_at_offset(version_str: str, repo_path: str):
     base_version, offset = get_version_and_offset(version_str)
-    previous_tag = get_previous_tag(base_version, repo_path)
+    tag_list = get_list_of_tags(repo_path)
+    previous_tag = get_previous_tag(base_version, tag_list)
     history = get_history_since(previous_tag, repo_path)
     print(
         f"Checkout to {offset} commits after the preceding tag {previous_tag}"

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch, MagicMock
 
 import textwrap
 
@@ -33,7 +33,7 @@ class TestSnapInfoUtility(unittest.TestCase):
             snap_info_utility.get_version_and_offset(version)
 
     @patch("snap_info_utility.check_output")
-    def test_get_previous_tag(self, mock_check_output):
+    def test_get_list_of_tags(self, mock_check_output):
         mock_check_output.return_value = textwrap.dedent(
             """
             v1.2.3
@@ -41,15 +41,22 @@ class TestSnapInfoUtility(unittest.TestCase):
             v1.2.1
             """
         )
-        result = snap_info_utility.get_previous_tag("1.2.3", "/path/to/repo")
+        result = snap_info_utility.get_list_of_tags("/path/to/repo")
+        self.assertEqual(result, ["v1.2.3", "v1.2.2", "v1.2.1"])
+
+    @patch("snap_info_utility.check_output")
+    def test_get_list_of_tags_error(self, mock_check_output):
+        mock_check_output.return_value = ""
+        with self.assertRaises(SystemExit):
+            snap_info_utility.get_list_of_tags("/path/to/repo")
+
+    @patch("snap_info_utility.check_output")
+    def test_get_previous_tag(self, mock_check_output):
+        tags = ["v1.2.3", "v1.2.2", "v1.2.1"]
+        result = snap_info_utility.get_previous_tag("1.2.3", tags)
         self.assertEqual(result, "v1.2.2")
 
-        result = snap_info_utility.get_previous_tag("1.2.2", "/path/to/repo")
-        self.assertEqual(result, "v1.2.1")
-
-        with self.assertRaises(SystemExit):
-            snap_info_utility.get_previous_tag("1.0.0", "/path/to/repo")
-
+    @patch("snap_info_utility.get_list_of_tags", MagicMock())
     @patch("snap_info_utility.get_previous_tag")
     @patch("snap_info_utility.get_history_since")
     def test_get_revision_at_offset(
@@ -69,6 +76,7 @@ class TestSnapInfoUtility(unittest.TestCase):
 
         self.assertEqual(result, "tag_hash + 2")
 
+    @patch("snap_info_utility.get_list_of_tags", MagicMock())
     @patch("snap_info_utility.get_previous_tag")
     @patch("snap_info_utility.get_history_since")
     def test_get_revision_at_offset_error(

--- a/version-published/test_snap_info_utility.py
+++ b/version-published/test_snap_info_utility.py
@@ -28,7 +28,7 @@ class TestSnapInfoUtility(unittest.TestCase):
         self.assertEqual(b_version, "1.2")
         self.assertEqual(offset, 0)
 
-        version = "1.2.3-dv25"
+        version = "bad.version.devbad"
         with self.assertRaises(SystemExit):
             snap_info_utility.get_version_and_offset(version)
 
@@ -41,14 +41,14 @@ class TestSnapInfoUtility(unittest.TestCase):
             v1.2.1
             """
         )
-        result = snap_info_utility.get_previous_tag("v1.2.3", "/path/to/repo")
+        result = snap_info_utility.get_previous_tag("1.2.3", "/path/to/repo")
         self.assertEqual(result, "v1.2.2")
 
-        result = snap_info_utility.get_previous_tag("v1.2.2", "/path/to/repo")
+        result = snap_info_utility.get_previous_tag("1.2.2", "/path/to/repo")
         self.assertEqual(result, "v1.2.1")
 
         with self.assertRaises(SystemExit):
-            snap_info_utility.get_previous_tag("v1.0.0", "/path/to/repo")
+            snap_info_utility.get_previous_tag("1.0.0", "/path/to/repo")
 
     @patch("snap_info_utility.get_previous_tag")
     @patch("snap_info_utility.get_history_since")

--- a/version-published/tox.ini
+++ b/version-published/tox.ini
@@ -4,6 +4,10 @@ skip_missing_interpreters = true
 isolated_build = True
 
 [testenv]
+# Force the packaging library to be uninstalled before running the tests
+# to match the behavior of jenkins runners
+commands_pre =
+    pip uninstall -y packaging
 commands =
     {envpython} -m coverage run -m pytest .
     {envpython} -m coverage report


### PR DESCRIPTION
This new version should work well even when using the default `distutils.version import LooseVersion` with python 3.8.
