### PR TITLE
add(scriplets): run command on host via SSH

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -88,10 +88,10 @@ wait_for_ssh --allow-degraded \
 && install_on_device \
 || exit 1
 
-# install agent dependencies
+echo "Installing agent dependencies"
 install_packages pipx python3-venv sshpass > /dev/null
 
-# install launcher tool on the agent
+echo "Installing agent tools"
 pipx install --spec $TOOLS_PATH/cert-tools/launcher launcher > /dev/null
 
 # restore tracing (if previously enabled)

--- a/install_tools.sh
+++ b/install_tools.sh
@@ -88,9 +88,10 @@ wait_for_ssh --allow-degraded \
 && install_on_device \
 || exit 1
 
+# install agent dependencies
+install_packages pipx python3-venv sshpass > /dev/null
+
 # install launcher tool on the agent
-echo "Installing pipx"
-install_packages pipx python3-venv > /dev/null
 pipx install --spec $TOOLS_PATH/cert-tools/launcher launcher > /dev/null
 
 # restore tracing (if previously enabled)

--- a/scriptlets/_run_zapper
+++ b/scriptlets/_run_zapper
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Run a command on a remote Zapper via SSH
+#
+# Description:
+#
+# The IP of the Zapper is provided by the environment variable ZAPPER_IP,
+# which must be set. The user name on the Zapper is `ubuntu`
+# and password is `insecure`. SSH authorization is password-based and
+# achieved via `sshpass`. 
+#
+# This script sources `defs/set_ssh_options` to set SSH_OPTS.
+# This script sources `defs/check_for_zapper_ip` to check that DEVICE_IP is set.
+#
+# Return value:
+#
+# The value returned by the command on the Zapper, or 255 in case
+# of an ssh error
+
+usage() {
+    echo "Usage: $(basename ${BASH_SOURCE[0]}) <command>"
+}
+
+
+if [ $# -lt 1 ]; then
+    usage
+    echo "Error: <command> not specified"
+    exit 1
+fi
+
+source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip"
+source "$(dirname ${BASH_SOURCE[0]})/defs/ssh_options"
+sshpass -p insecure ssh $SSH_OPTS ubuntu@$ZAPPER_IP "$@"

--- a/scriptlets/defs/check_for_zapper_ip
+++ b/scriptlets/defs/check_for_zapper_ip
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Check if the environment variable $ZAPPER_IP is set
+#
+# This file is primarily meant to be sourced.
+
+if [ -z $ZAPPER_IP ]; then
+    echo "Error $(basename "${BASH_SOURCE[-1]}"): Environment variable ZAPPER_IP not set"
+    exit 1
+fi


### PR DESCRIPTION
Similarly to the `_run` scriplet, this PR introduces `_run`, to run commands over SSH on a target host. Username/Password are static and defined by the host image, SSH authentication is achieved via `sshpass`.

Tested it locally running a command on a host in the lab.