### PR TITLE
Add: a scriptlet to refresh the machine snap and firmware

### DIFF
--- a/scriptlets/_run_zapper
+++ b/scriptlets/_run_zapper
@@ -28,6 +28,7 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
-source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip"
+check_for_zapper_ip || exit 1
+
 source "$(dirname ${BASH_SOURCE[0]})/defs/ssh_options"
 sshpass -p insecure ssh $SSH_OPTS ubuntu@$ZAPPER_IP "$@"

--- a/scriptlets/check_for_zapper_ip
+++ b/scriptlets/check_for_zapper_ip
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 # Check if the environment variable $ZAPPER_IP is set
-#
-# This file is primarily meant to be sourced.
 
 if [ -z $ZAPPER_IP ]; then
     echo "Error $(basename "${BASH_SOURCE[-1]}"): Environment variable ZAPPER_IP not set"

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Update the Zapper snap (and firmware) if needed
+#
+# Description:
+#
+# If a Zapper is part of the setup, refresh the snap
+# to the target channel (default is `beta`), upgrade firmware
+# and wait until the service is stable. 
+
+usage() {
+    echo "Usage: $(basename ${BASH_SOURCE[0]}) [--channel]"
+}
+
+check_for_zapper () {
+    (
+        trap EXIT
+        source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip" > /dev/null
+    )
+}
+
+wait_zapper_service_stable() {
+    previous_addon_count=-1
+    stable_count=0
+    max_stable_checks=3
+    while true; do
+        current_addon_count=$(eval "_run_zapper zapper addon list 2> /dev/null" | wc -l)
+        if [[ "$current_addon_count" -eq "$previous_addon_count" ]]; then
+          ((stable_count++))
+        else
+          stable_count=0
+        fi
+
+        if [[ "$stable_count" -ge "$max_stable_checks" ]]; then
+          break
+        fi
+
+        previous_addon_count="$current_addon_count"
+    done
+}
+
+CHANNEL=beta
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --channel)
+            CHANNEL=$2
+            shift
+            ;;
+        *)
+            usage
+            echo "Error: Invalid argument $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+check_for_zapper
+if [ $? -ne 0 ]; then
+    exit 0
+fi
+
+message=$(_run_zapper sudo snap refresh zapper --amend --channel $CHANNEL 2>&1)
+if echo "$message" | grep -q 'no updates available'; then
+    echo "Snap was up-to-date, restarting the service instead..."
+    _run_zapper sudo snap restart zapper
+fi
+wait_zapper_service_stable
+
+message=$(_run_zapper zapper firmware update -y --allow-older)
+if echo "$message" | grep -q 'update in progress'; then
+    echo "Firmware(s) got upgraded, waiting again for the service to stabilize..."
+    wait_zapper_service_stable
+fi

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -28,8 +28,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# Running in a subshell to not exit with error like it normally would when failing
-(source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip" >> /dev/null)
+check_for_zapper_ip >> /dev/null || exit 0
 
 message=$(_run_zapper sudo snap refresh zapper --amend --channel $CHANNEL 2>&1)
 if echo "$message" | grep -q 'no updates available'; then

--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -6,37 +6,10 @@
 #
 # If a Zapper is part of the setup, refresh the snap
 # to the target channel (default is `beta`), upgrade firmware
-# and wait until the service is stable. 
+# and wait until the add-ons are recognized.
 
 usage() {
     echo "Usage: $(basename ${BASH_SOURCE[0]}) [--channel]"
-}
-
-check_for_zapper () {
-    (
-        trap EXIT
-        source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip" > /dev/null
-    )
-}
-
-wait_zapper_service_stable() {
-    previous_addon_count=-1
-    stable_count=0
-    max_stable_checks=3
-    while true; do
-        current_addon_count=$(eval "_run_zapper zapper addon list 2> /dev/null" | wc -l)
-        if [[ "$current_addon_count" -eq "$previous_addon_count" ]]; then
-          ((stable_count++))
-        else
-          stable_count=0
-        fi
-
-        if [[ "$stable_count" -ge "$max_stable_checks" ]]; then
-          break
-        fi
-
-        previous_addon_count="$current_addon_count"
-    done
 }
 
 CHANNEL=beta
@@ -55,20 +28,18 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-check_for_zapper
-if [ $? -ne 0 ]; then
-    exit 0
-fi
+# Running in a subshell to not exit with error like it normally would when failing
+(source "$(dirname ${BASH_SOURCE[0]})/defs/check_for_zapper_ip" >> /dev/null)
 
 message=$(_run_zapper sudo snap refresh zapper --amend --channel $CHANNEL 2>&1)
 if echo "$message" | grep -q 'no updates available'; then
     echo "Snap was up-to-date, restarting the service instead..."
     _run_zapper sudo snap restart zapper
 fi
-wait_zapper_service_stable
+wait_for_zapper_addons
 
 message=$(_run_zapper zapper firmware update -y --allow-older)
 if echo "$message" | grep -q 'update in progress'; then
-    echo "Firmware(s) got upgraded, waiting again for the service to stabilize..."
-    wait_zapper_service_stable
+    echo "Firmware(s) got upgraded, waiting again for the add-on discovery..."
+    wait_for_zapper_addons
 fi

--- a/scriptlets/wait_for_zapper_addons
+++ b/scriptlets/wait_for_zapper_addons
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Busy loop around the Zapper add-on discovery process
+#
+# Description:
+#
+# Once the Zapper service starts, the Zapper starts a
+# discovery process to recognize every add-on connected
+# to the add-on bus. This scriptlet polls the zapper
+# add-on list until the length is stable for 3 consecutive
+# iterations.
+
+previous_addon_count=-1
+stable_count=0
+max_stable_checks=3
+while true; do
+    current_addon_count=$(_run_zapper zapper addon list 2> /dev/null | wc -l)
+    if [[ "$current_addon_count" -eq "$previous_addon_count" ]]; then
+      ((stable_count++))
+    else
+      stable_count=0
+    fi
+
+    if [[ "$stable_count" -ge "$max_stable_checks" ]]; then
+      break
+    fi
+
+    previous_addon_count="$current_addon_count"
+done


### PR DESCRIPTION
This PR adds a scriptlet to refresh the snap when it's part of the DUT setup, upgrade firmware and wait until the service is stable. The need of such scriplet comes from the fact that we're going to start using multiple channels for the snap: `edge` for daily builds and canary validation and `beta` for any other usage in the lab.

Also, this would be the trigger for firmware upgrade which is not performed in other automatic way ATM.

### Tests
 Snap up-to-date: https://testflinger.canonical.com/jobs/b88002a2-8c76-4231-a695-c7d60d298766
 Snap outdated: https://testflinger.canonical.com/jobs/957c6b48-d212-49ad-b5e8-29b66bd86267
 FW outdated: https://testflinger.canonical.com/jobs/c339d95f-397f-4277-aa1f-1e7feb4b26ec
 To edge channel: https://testflinger.canonical.com/jobs/143a159c-1dbd-4ee4-8673-01b6c1ce7822