### PR TITLE
New: Scriplet that clean everything from a previous run 

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -35,7 +35,7 @@ install_on_device() {
 
     # copy selected scriptlets over to the device
     # and then move them somewhere in the device's PATH
-    DEVICE_SCRIPTLETS=(retry check_for_packages_complete wait_for_packages_complete install_packages)
+    DEVICE_SCRIPTLETS=(retry check_for_packages_complete wait_for_packages_complete install_packages clean_machine)
     _put "${DEVICE_SCRIPTLETS[@]/#/$SCRIPTLETS_PATH/}" :
     _run sudo mv "${DEVICE_SCRIPTLETS[@]}" $REMOTE_PATH
 

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -38,7 +38,7 @@ if [ -n "$CHECKBOX_DEBS" ]; then
     echo "Found the following Checkbox debs"
     echo "  " $CHECKBOX_DEBS
     echo "Deleting them..."
-    apt purge -y -qq $CHECKBOX_DEBS
+    apt-get purge -y -qq $CHECKBOX_DEBS
 fi
 
 # delete old sessions, as Checkbox will try to resume them when started,
@@ -58,11 +58,10 @@ fi
 # from the wrong source. Also removing /ppa and /testing which are legacy names
 # of /edge and /beta that may still be used somewhere
 echo "Trying to remove all Checkbox ppas"
-add-apt-repository --remove -y ppa:checkbox-dev/ppa
-add-apt-repository --remove -y ppa:checkbox-dev/testing
-add-apt-repository --remove -y ppa:checkbox-dev/edge
-add-apt-repository --remove -y ppa:checkbox-dev/beta
-add-apt-repository --remove -y ppa:checkbox-dev/stable
+RISKS="ppa testing edge beta stable"
+for risk in $RISKS; do
+  sudo add-apt-repository --remove -y ppa:checkbox-dev/$risk > /dev/null && echo "Removed ppa:checkbox-dev/$risk"
+done
 
 # Also remove any cloned version of Checkbox in any home, as this will clash
 # with anything trying to provision from source

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -49,7 +49,7 @@ if [ -d "/var/tmp/checkbox-ng" ]; then
 fi
 
 # delete any provider that was globally "developed" (installed in editable mode)
-if [ -d "/var/tmp/checkbox-providers-develop/"]; then
+if [ -d "/var/tmp/checkbox-providers-develop/" ]; then
   echo "Removing all developed providers"
   rm -rf /var/tmp/checkbox-providers-develop
 fi

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -1,5 +1,5 @@
 #!/bin/bash
-# this is a generic clean script that deletes any thing that may break the
+# This is a generic clean script that deletes any thing that may break the
 # current test run due to a previous run. This is especially useful for
 # noprovision machines.
 

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -23,7 +23,7 @@ set +e
 # delete all checkbox snaps, this includes any frontend or custom frontend
 # (they all contain checkbox in their name). This should also purge any
 # running checkbox*agent service
-CHECKBOX_SNAPS=$(snap list | \grep -E 'checkbox' | \grep -P -o "^[\w-]+")
+CHECKBOX_SNAPS=$(snap list | grep -E 'checkbox' | grep -P -o "^[\w-]+")
 if [ -n "$CHECKBOX_SNAPS" ]; then
     echo "Found the following Checkbox snaps"
     echo "  " $CHECKBOX_SNAPS
@@ -33,7 +33,7 @@ fi
 
 # delete all installed Checkbox debian packages. This should also purge any
 # previously installed provider
-CHECKBOX_DEBS=$(apt list --installed | \grep checkbox | \grep -P -o "^[\w-]+")
+CHECKBOX_DEBS=$(apt list --installed | grep checkbox | grep -P -o "^[\w-]+")
 if [ -n "$CHECKBOX_DEBS" ]; then
     echo "Found the following Checkbox debs"
     echo "  " $CHECKBOX_DEBS

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -28,7 +28,7 @@ if [ -n "$CHECKBOX_SNAPS" ]; then
     echo "Found the following Checkbox snaps"
     echo "  " $CHECKBOX_SNAPS
     echo "Deleting them..."
-    snap remove $CHECKBOX_SNAPS
+    sudo snap remove $CHECKBOX_SNAPS
 fi
 
 # delete all installed Checkbox debian packages. This should also purge any
@@ -38,7 +38,7 @@ if [ -n "$CHECKBOX_DEBS" ]; then
     echo "Found the following Checkbox debs"
     echo "  " $CHECKBOX_DEBS
     echo "Deleting them..."
-    apt-get purge -y -qq $CHECKBOX_DEBS
+    sudo apt-get purge -y -qq $CHECKBOX_DEBS
 fi
 
 # delete old sessions, as Checkbox will try to resume them when started,
@@ -68,5 +68,5 @@ done
 CHECKBOX_SOURCE_CLONES=$(find /home/ -maxdepth 2 -name "*checkbox*" -type d)
 if [ -n "$CHECKBOX_SOURCE_CLONES" ]; then
   echo "Removing all clones of Checkbox on the machine"
-  rm -rf $CHECKBOX_SOURCE_CLONES
+  sudo rm -rf $CHECKBOX_SOURCE_CLONES
 fi

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -1,0 +1,73 @@
+#!/bin/bash
+# this is a generic clean script that deletes any thing that may break the
+# current test run due to a previous run. This is especially useful for
+# noprovision machines.
+
+# We can do all these things without checking the result as we may be running
+# in any situation, so the previous run could have installed a snap, deb, source
+# etc.
+
+# First lets check that launching this was intentional
+
+if [ "$1" = "--im-sure" ]; then
+  echo "Cleaning the machine"
+else
+  echo "This is dangerous as it tries to purge an environment before running"
+  echo "the tests. You should not launch this on your own machine."
+  echo "if you are sure launch: `basename "$0"` --im-sure"
+  exit 1
+fi
+
+set +e
+
+# delete all checkbox snaps, this includes any frontend or custom frontend
+# (they all contain checkbox in their name). This should also purge any
+# running checkbox*agent service
+CHECKBOX_SNAPS=$(snap list | \grep -E 'checkbox' | \grep -P -o "^[\w-]+")
+if [ -n "$CHECKBOX_SNAPS" ]; then
+    echo "Found the following Checkbox snaps"
+    echo "  " $CHECKBOX_SNAPS
+    echo "Deleting them..."
+    snap remove $CHECKBOX_SNAPS
+fi
+
+# delete all installed Checkbox debian packages. This should also purge any
+# previously installed provider
+CHECKBOX_DEBS=$(apt list --installed | \grep checkbox | \grep -P -o "^[\w-]+")
+if [ -n "$CHECKBOX_DEBS" ]; then
+    echo "Found the following Checkbox debs"
+    echo "  " $CHECKBOX_DEBS
+    echo "Deleting them..."
+    apt purge -y -qq $CHECKBOX_DEBS
+fi
+
+# delete old sessions, as Checkbox will try to resume them when started,
+# but this is a new test session, so this is not desirable
+if [ -d "/var/tmp/checkbox-ng" ]; then
+  echo "Removing all old sessions still on the machine"
+  rm -rf /var/tmp/checkbox-ng
+fi
+
+# delete any provider that was globally "developed" (installed in editable mode)
+if [ -d "/var/tmp/checkbox-providers-develop/"]; then
+  echo "Removing all developed providers"
+  rm -rf /var/tmp/checkbox-providers-develop
+fi
+
+# remove all ppa repos pre-configured as they may make the installer install
+# from the wrong source
+# leave also /ppa and /testing, legacy names of /edge and /beta
+echo "Trying to remove all Checkbox ppas"
+add-apt-repository --remove -y ppa:checkbox-dev/ppa
+add-apt-repository --remove -y ppa:checkbox-dev/testing
+add-apt-repository --remove -y ppa:checkbox-dev/edge
+add-apt-repository --remove -y ppa:checkbox-dev/beta
+add-apt-repository --remove -y ppa:checkbox-dev/stable
+
+# Also remove any cloned version of Checkbox in any home, as this will clash
+# with anything trying to provision from source
+CHECKBOX_SOURCE_CLONES=$(find /home/ -maxdepth 2 -name "*checkbox*" -type d)
+if [ -n "$CHECKBOX_SOURCE_CLONES" ]; then
+  echo "Removing all clones of Checkbox on the machine"
+  rm -rf $CHECKBOX_SOURCE_CLONES
+fi

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -68,5 +68,7 @@ done
 CHECKBOX_SOURCE_CLONES=$(find /home/ -maxdepth 2 -name "*checkbox*" -type d)
 if [ -n "$CHECKBOX_SOURCE_CLONES" ]; then
   echo "Removing all clones of Checkbox on the machine"
+  echo "Removing the following clones:"
+  echo "$CHECKBOX_SOURCE_CLONES"
   sudo rm -rf $CHECKBOX_SOURCE_CLONES
 fi

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -55,8 +55,8 @@ if [ -d "/var/tmp/checkbox-providers-develop/"]; then
 fi
 
 # remove all ppa repos pre-configured as they may make the installer install
-# from the wrong source
-# leave also /ppa and /testing, legacy names of /edge and /beta
+# from the wrong source. Also removing /ppa and /testing which are legacy names
+# of /edge and /beta that may still be used somewhere
 echo "Trying to remove all Checkbox ppas"
 add-apt-repository --remove -y ppa:checkbox-dev/ppa
 add-apt-repository --remove -y ppa:checkbox-dev/testing


### PR DESCRIPTION
We have quite a few lines in all templates dedicated to clean up what the previous job left behind. These are mainly used for noprovision machine. Given that I need something very similar, this is my implementation as a scriplet we can call instead of the multiple lines.

Tests:
- Missing `--im-sure` run (which I definetly intended to create and didn't do it by mistake): https://github.com/canonical/checkbox/actions/runs/11103858615/job/30846714818
- Actual run: https://github.com/canonical/checkbox/actions/runs/11104217105/job/30847831704#step:5:512