### PR TITLE
[RTW-372] feat: add `--allow-starting` flag to `check_for_ssh`

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -78,7 +78,9 @@ add_to_path $SCRIPTLETS_PATH
 add_to_path $SCRIPTLETS_PATH/sru-helpers
 add_to_path ~/.local/bin
 
-wait_for_ssh --allow-degraded \
+# ensure that the device is reachable and copy over selected scriptlets
+# (testing reachability with --allow-starting is a single-try fallback option)
+(wait_for_ssh --allow-degraded || check_for_ssh --allow-starting) \
 && echo "Installing selected scriptlets on the device" \
 && install_on_device \
 || exit 1

--- a/scriptlets/check_for_ssh
+++ b/scriptlets/check_for_ssh
@@ -19,13 +19,32 @@
 # or 255 in case of an ssh failure
 
 usage() {
-    echo "Usage: $(basename ${BASH_SOURCE[0]}) [--allow-degraded]"
+    echo "Usage: $(basename ${BASH_SOURCE[0]}) [--allow-degraded|--allow-starting]"
 }
 
+ALLOW_DEGRADED=False
+ALLOW_STARTING=False
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --allow-degraded)
-            ALLOW_DEGRADED="(degraded allowed)"
+            if [ -z "$ALLOW" ]; then
+                ALLOW="(degraded allowed)"
+                ALLOW_DEGRADED=True
+            else
+                usage
+                echo "Error: multiple --allow flags used"
+                exit 1
+            fi
+            ;;
+        --allow-starting)
+            if [ -z "$ALLOW" ]; then
+                ALLOW="(starting allowed)"
+                ALLOW_STARTING=True
+            else
+                usage
+                echo "Error: multiple --allow flags used"
+                exit 1
+            fi
             ;;
         *)
             usage
@@ -36,13 +55,15 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-echo "Checking if ${DEVICE_IP:-device} is fully up and running $ALLOW_DEGRADED"
+echo "Checking if ${DEVICE_IP:-device} is fully up and running $ALLOW"
 RESULT=$(_run systemctl is-system-running)
 STATUS=$?
 [ -n "$RESULT" ] && echo $RESULT
 # check returned result and propagate `_run`'s exit status if not successful
-if [ -z "$ALLOW_DEGRADED" ]; then
-    [[ "$RESULT" =~ ^running ]] || exit $STATUS
-else
+if [ "$ALLOW_DEGRADED" = "True" ]; then
     [[ "$RESULT" =~ ^(running|degraded) ]] || exit $STATUS
+elif [ "$ALLOW_STARTING" = "True" ]; then
+    [[ "$RESULT" =~ ^(running|starting) ]] || exit $STATUS
+else
+    [[ "$RESULT" =~ ^running ]] || exit $STATUS
 fi


### PR DESCRIPTION
## Description

The [scriptlet installer](https://github.com/canonical/hwcert-jenkins-tools/blob/12ce5f3d3ba3dddc75cf03824bea025c4218778d/install_tools.sh#L81) uses the `wait_for_ssh` scriptlet to make sure a device is up-and-running before performing any other actions on it. The installer (and any certification task that uses it) fails if `wait_for_ssh` fails.

In order for `wait_for_ssh` to succeed, the output of `systemctl is-system-running` on the device needs to be `running` or (if so specified) `degraded`. Any other state will result in `wait_for_ssh` retrying and eventually failing.

However, some of 20.04 OEM machines need to disable the `pc-sanity-backgroud-photo.service` before the test run, since it's the service that blocks the booting process. Here is an [example run](http://10.102.156.15:8080/job/cert-oem-sru-focal-desktop-dell-optiplex-3000-thin-client-c29197/) where the issue manifests itself.

This PR is an attempt to resolve the issue by:
- extending the `check_for_ssh` scriptlet to accept an `--allow-starting` flag, so that it can complete successfully even when the device status is `starting`
- adds a fallback mechanism to the scriptlet installer: if it fails to connect to the device using the existing `wait_for_ssh` approach it tries _once_ to `check_for_ssh --allow-starting`.

This mechanism allows the installer to complete so that any script that uses it can then proceed to disable the offending blocking service.

## Resolved Issue

Resolved [RTW-372](https://warthogs.atlassian.net/browse/RTW-372).

## Tests

Modifying the job provided as an example above to retrieve and run the installer from this branch resolves the issue, in the sense that [the installer resorts to the fallback mechanism](http://10.102.156.15:8080/job/cert-oem-sru-focal-desktop-dell-optiplex-3000-thin-client-c29197/7/consoleFull) and _does not fail_. 

[RTW-372]: https://warthogs.atlassian.net/browse/RTW-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ