### PR TITLE
Improve the reliability of Test Observer's rerunner script

### DIFF
--- a/.github/workflows/test_test_executions_rerunner.yaml
+++ b/.github/workflows/test_test_executions_rerunner.yaml
@@ -1,0 +1,25 @@
+name: Test TestObserver's TestExecutions Rerunner
+on:
+  push:
+    branches-ignore:
+      - 'main'
+    paths:
+      - 'scriptlets/test-executions-rerunner/**'
+      - '.github/workflows/test_test_executions_rerunner.yaml'
+# Cancel inprogress runs if new commit pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test-rerunner-script:
+    runs-on: [self-hosted, linux, large, jammy, x64]
+    defaults:
+      run:
+        working-directory: scriptlets/test-executions-rerunner
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - run: pip install tox
+      - run: tox

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .mypy_cache
 .ruff_cache
 .tox
+.venv

--- a/scriptlets/test-executions-rerunner/requirements.txt
+++ b/scriptlets/test-executions-rerunner/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+urllib3==2.2.3

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.INFO)
 requests = Session()
 retries = Retry(
     total=3,
-    backoff_factor=0.1,
+    backoff_factor=3,
     status_forcelist=[408, 429, 502, 503, 504],
     allowed_methods={"POST", "GET", "DELETE", "PUT"},
 )


### PR DESCRIPTION
Resolves https://warthogs.atlassian.net/browse/RTW-374

Changes:
- Adds requests timeout to avoid hanging
- Adds requests retries to improve reliability
- Brings back CI that tests this script as it seems to have been accidentally deleted at some point

Testing:
- Automated testing
- Also manually deployed this branch [here](http://10.102.156.15:8080/job/test-executions-rerunner/44385/) and sure enough it reran the [job](http://10.102.156.15:8080/job/cert-rpi400-arm64-pi-kernel-18-pi-beta/106/) correctly 