### PR TITLE
[CERTTF-425] feat: add scriptlets for checking and parsing the scenario file

### DIFF
--- a/scriptlets/check_for_scenario_file
+++ b/scriptlets/check_for_scenario_file
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Check if the environment variable $SCENARIO_FILE is set
+# and points to a valid JSON file
+
+if [ -z "$SCENARIO_FILE" ]; then
+    echo "Error $(basename "${BASH_SOURCE[-1]}"): Environment variable SCENARIO_FILE not set"
+    exit 1
+fi
+
+if [ ! -f "$SCENARIO_FILE" ]; then
+    echo "Error $(basename "${BASH_SOURCE[-1]}"): SCENARIO_FILE set to $SCENARIO_FILE is not a file"
+    exit 1
+fi
+
+if ! jq empty "$SCENARIO_FILE"; then
+    echo "Error $(basename "${BASH_SOURCE[-1]}"): SCENARIO_FILE set to '$SCENARIO_FILE' is not a valid JSON file"
+    exit 1
+fi

--- a/scriptlets/scenario
+++ b/scriptlets/scenario
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Access the SCENARIO_FILE and output the key specified
+# by the first argument, e.g. config job.artifact.series
+#
+# If the key is not present in the SCENARIO_FILE, the output is "null"
+# 
+# Return value:
+#
+# 0 if the key is present in the SCENARIO_FILE
+# Non-zero otherwise (because of the -e option provided to jq)
+
+dot_to_brackets() {
+    # convert a simple dot-delimited filter like a.b.c
+    # to a safer, quoted filter like .["a"]["b"]["c"]
+    # by replacing dots with "][" and adding .[" and "]
+    # to the beginning and end of the filter
+    echo "$1" | sed 's/\./\"\]\[\"/g; s/^/\.\[\"/; s/$/\"\]/'
+}
+
+jq -r -e $(dot_to_brackets "$1") "$SCENARIO_FILE"

--- a/scriptlets/scenario
+++ b/scriptlets/scenario
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Access the SCENARIO_FILE and output the key specified
-# by the first argument, e.g. config job.artifact.series
+# by the first argument, e.g. scenario job.artifact.series
 #
 # If the key is not present in the SCENARIO_FILE, the output is "null"
 # 


### PR DESCRIPTION
# Description

This PR introduces scriptlets that check and parse a "scenario" file, a JSON file that holds all the information required for a specific test run. Specifically:
- `check_for_scenario_file` makes sure the `SCENARIO_FILE` environment variable has been set and points to a valid JSON file
- `scenario` accesses the scenario file and retrieves a specific key

# Tests

This [Testflinger job run](https://testflinger.canonical.com/jobs/2b022aa7-3aa2-4044-b5a4-78935e6e64ca) illustrates how these scriptlets would be used during testing, with the scenario file provided as an attachment.