### PR TITLE
Increase the default timeout of package and snap waiting

### DIFF
--- a/scriptlets/wait_for_packages_complete
+++ b/scriptlets/wait_for_packages_complete
@@ -10,7 +10,7 @@
 # apt-get, dpkg) are killed.
 #
 # Return value:
-# 
+#
 # 0 if `check_for_packages_complete` is successful, or a timeout has occurred
 # 1 if `check_for_packages_complete` cannot be executed or is unsuccesful on the last retry
 
@@ -19,7 +19,7 @@ usage() {
 }
 
 NO_FILES_CHECK=""
-TIMEOUT="10m"
+TIMEOUT="30m"
 DELAY=10
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/scriptlets/wait_for_snap_changes
+++ b/scriptlets/wait_for_snap_changes
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 
 # Wait for all snap changes on a remote device to complete
-# 
+#
 # See `check_for_snap_changes` (which is repeatedly called here)
 # for details
 #
 # Return value:
-# 
+#
 # 0 if `check_for_snap_changes` is successful or 1 otherwise
 
 usage() {
     echo "Usage: $(basename $0) [--times TIMES] [--delay DELAY]"
 }
 
-TIMES=40
+# 1h 30m max time (180 * 30 / 60 seconds)
+TIMES=180
 DELAY=30
 while [[ "$#" -gt 0 ]]; do
     case $1 in


### PR DESCRIPTION
This increases the default timeout of the `wait_for_snap_changes` and `wait_for_packages_complete` scriplet making it triple what it was. This is because when the network is slow in the lab both can fail (printing something) but without halting the job (as we don't catch the return code). This leads sometimes to failures further down the line that are difficoult to debug as one has to scroll back and catch that this happened.  