### PR TITLE
[RTW-399] Update select scriptlets for use in snap-testing jobs

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -75,16 +75,16 @@ add_to_path $SCRIPTLETS_PATH
 add_to_path $SCRIPTLETS_PATH/sru-helpers
 add_to_path ~/.local/bin
 
-log "Installing agent dependencies"
+echo "Installing agent dependencies"
 install_packages pipx python3-venv sshpass jq > /dev/null
 
-log "Installing agent tools"
+echo "Installing agent tools"
 pipx install --spec $TOOLS_PATH/cert-tools/launcher launcher > /dev/null
 
 # ensure that the device is reachable and copy over selected scriptlets
 # (testing reachability with --allow-starting is a single-try fallback option)
 (wait_for_ssh --allow-degraded || check_for_ssh --allow-starting) \
-&& log "Installing selected scriptlets on the device" \
+&& echo "Installing selected scriptlets on the device" \
 && install_on_device \
 || exit 1
 

--- a/scriptlets/check_for_checkbox_service
+++ b/scriptlets/check_for_checkbox_service
@@ -31,6 +31,6 @@ STATUS=$(_run 'systemctl is-active *checkbox*.service')
 # display services to facilitate diagnostics
 if [ $# -eq 1 ]; then
     echo "The Checkbox service is not active on ${DEVICE_IP:-device}"
-    _run systemctl list-units --type=service
+    _run systemctl list-units --type=service --all | grep checkbox
 fi
 exit 1

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -31,14 +31,25 @@ if [ -n "$CHECKBOX_SNAPS" ]; then
     sudo snap remove $CHECKBOX_SNAPS
 fi
 
-# delete all installed Checkbox debian packages. This should also purge any
-# previously installed provider
-CHECKBOX_DEBS=$(apt list --installed | grep checkbox | grep -P -o "^[\w-]+")
-if [ -n "$CHECKBOX_DEBS" ]; then
-    echo "Found the following Checkbox debs"
-    echo "  " $CHECKBOX_DEBS
-    echo "Deleting them..."
-    sudo apt-get purge -y -qq $CHECKBOX_DEBS
+# Only relevant on non-Core systems where package-handling is supported:
+if apt-get --help > /dev/null 2>&1; then
+    # delete all installed Checkbox debian packages. This should also purge any
+    # previously installed provider
+    CHECKBOX_DEBS=$(apt list --installed | grep checkbox | grep -P -o "^[\w-]+")
+    if [ -n "$CHECKBOX_DEBS" ]; then
+        echo "Found the following Checkbox debs"
+        echo "  " $CHECKBOX_DEBS
+        echo "Deleting them..."
+        sudo apt-get purge -y -qq $CHECKBOX_DEBS
+    fi
+    # remove all ppa repos pre-configured as they may make the installer install
+    # from the wrong source. Also removing /ppa and /testing which are legacy names
+    # of /edge and /beta that may still be used somewhere
+    echo "Trying to remove all Checkbox ppas"
+    RISKS="ppa testing edge beta stable"
+    for risk in $RISKS; do
+      sudo add-apt-repository --remove -y ppa:checkbox-dev/$risk > /dev/null && echo "Removed ppa:checkbox-dev/$risk"
+    done
 fi
 
 # delete old sessions, as Checkbox will try to resume them when started,
@@ -53,15 +64,6 @@ if [ -d "/var/tmp/checkbox-providers-develop/" ]; then
   echo "Removing all developed providers"
   rm -rf /var/tmp/checkbox-providers-develop
 fi
-
-# remove all ppa repos pre-configured as they may make the installer install
-# from the wrong source. Also removing /ppa and /testing which are legacy names
-# of /edge and /beta that may still be used somewhere
-echo "Trying to remove all Checkbox ppas"
-RISKS="ppa testing edge beta stable"
-for risk in $RISKS; do
-  sudo add-apt-repository --remove -y ppa:checkbox-dev/$risk > /dev/null && echo "Removed ppa:checkbox-dev/$risk"
-done
 
 # Also remove any cloned version of Checkbox in any home, as this will clash
 # with anything trying to provision from source

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -56,19 +56,19 @@ fi
 # but this is a new test session, so this is not desirable
 if [ -d "/var/tmp/checkbox-ng" ]; then
   echo "Removing all old sessions still on the machine"
-  rm -rf /var/tmp/checkbox-ng
+  sudo rm -rf /var/tmp/checkbox-ng
 fi
 
 # delete any sideloaded provider
 if [ -d "/var/tmp/checkbox-providers/" ]; then
   echo "Removing all providers"
-  rm -rf /var/tmp/checkbox-providers
+  sudo rm -rf /var/tmp/checkbox-providers
 fi
 
 # delete any provider that was globally "developed" (installed in editable mode)
 if [ -d "/var/tmp/checkbox-providers-develop/" ]; then
   echo "Removing all developed providers"
-  rm -rf /var/tmp/checkbox-providers-develop
+  sudo rm -rf /var/tmp/checkbox-providers-develop
 fi
 
 # Also remove any cloned version of Checkbox in any home, as this will clash

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -59,6 +59,12 @@ if [ -d "/var/tmp/checkbox-ng" ]; then
   rm -rf /var/tmp/checkbox-ng
 fi
 
+# delete any sideloaded provider
+if [ -d "/var/tmp/checkbox-providers/" ]; then
+  echo "Removing all providers"
+  rm -rf /var/tmp/checkbox-providers
+fi
+
 # delete any provider that was globally "developed" (installed in editable mode)
 if [ -d "/var/tmp/checkbox-providers-develop/" ]; then
   echo "Removing all developed providers"

--- a/scriptlets/install_checkbox_debs
+++ b/scriptlets/install_checkbox_debs
@@ -43,4 +43,4 @@ export CHECKBOX_VERSION=$(_run checkbox-cli --version)
 echo "Installing checkbox $CHECKBOX_VERSION on the agent container from source"
 install_checkbox_agent_source $CHECKBOX_VERSION
 
-check_for_checkbox_service
+check_for_checkbox_service --debug

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -31,7 +31,7 @@ FRONTEND_TRACK=$3
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 
 # the runtime name is "checkboxYY";
-# YY is extracted from the "base" field of the front-end snap, which should be coreYY;
+# YY is extracted from the "base" field of the frontend snap, which should be coreYY;
 # the final "grep ." will cause this script to exit if there's no match
 RUNTIME_NAME="checkbox$(_run "snap info --verbose $FRONTEND_NAME" | sed -n 's/^base:\s*core\([0-9]\{2\}\)$/\1/p' | grep .)"
 RUNTIME_CHANNEL="latest/$RISK"
@@ -40,23 +40,23 @@ echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"
 _run sudo snap install --no-wait $RUNTIME_NAME --channel=$RUNTIME_CHANNEL
 wait_for_snap_changes
 
-# strict snaps need a different install flag and the connections to be made.
-# Checkbox Frontend snaps are strict on the tracks ucXX. Update
-# this regex to match more if alternative frontends need this as well
-[[ "$FRONTEND_TRACK" == uc* ]] && STRICT_FRONTEND=true || STRICT_FRONTEND=false
-
-if $STRICT_FRONTEND; then
-  NOTE="strict snap, using --devmode"
-  EXTRA_SNAP_INSTALL_FLAG="--devmode"
-else
-  NOTE="classic snap, using --classic"
-  EXTRA_SNAP_INSTALL_FLAG="--classic"
+# install the frontend snap as a strict snap and revert to classic if that fails
+# (strict snaps need a different install flag and the connections to be made)
+echo "Installing frontend snap: $FRONTEND_NAME from $FRONTEND_CHANNEL (as a strict snap, using --devmode)"
+STRICT_FRONTEND=true
+_run sudo snap install --no-wait $FRONTEND_NAME --devmode --channel=$FRONTEND_CHANNEL
+if [ "$?" -ne 0 ]; then
+    echo "Failed to install $FRONTEND_NAME as a strict snap"
+    echo "Installing frontend snap: $FRONTEND_NAME from $FRONTEND_CHANNEL (as a classic snap, using --classic)"
+    STRICT_FRONTEND=false
+    _run sudo snap install --no-wait $FRONTEND_NAME --classic --channel=$FRONTEND_CHANNEL
 fi
-
-echo "Installing front-end snap: $FRONTEND_NAME from $FRONTEND_CHANNEL ($NOTE)"
-_run sudo snap install --no-wait $FRONTEND_NAME $EXTRA_SNAP_INSTALL_FLAG --channel=$FRONTEND_CHANNEL
 wait_for_snap_changes
+
+# setting this flag is currently required for Checkbox to decide how to resume
 _run sudo snap set $FRONTEND_NAME agent=enabled
+
+# start the service
 _run sudo snap start $FRONTEND_NAME
 
 if $STRICT_FRONTEND; then
@@ -91,7 +91,7 @@ fi
 _run sudo snap refresh --no-wait $RUNTIME_NAME --channel=latest/$RISK
 wait_for_snap_changes
 
-# restart the service to make sure the latest version of the code is used
+# restart the service, to make sure the latest version of the code is used
 _run sudo snap restart $FRONTEND_NAME
 
 export CHECKBOX_VERSION=$(_run $FRONTEND_NAME.checkbox-cli --version)

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -57,6 +57,41 @@ get_runtime() {
     echo $RUNTIME_NAME
 }
 
+connect() {
+    # Collect unconnected frontend plugs (strip out the frontend name)
+    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '$3 == "-" {print $2}' | sed -n "s/$FRONTEND_NAME:\(.*\)$/\1/p")
+    # Collect unconnected runtime slots (strip out the runtime name)
+    # and keep them in a set (for quicker membership tests)
+    RUNTIME_SLOTS=$(_run snap connections "$RUNTIME_NAME" | awk '$2 == "-" {print $3}' | sed -n "s/$RUNTIME_NAME:\(.*\)$/\1/p")
+    declare -A RUNTIME_SLOT_SET
+    for SLOT in $RUNTIME_SLOTS; do RUNTIME_SLOT_SET[$SLOT]=$SLOT; done
+    # For each unconnected frontend plug, check if you can connect to a matching runtime slot
+    while read -r PLUG; do
+        SLOT=${RUNTIME_SLOT_SET[$PLUG]}
+        if [ -n "$SLOT" ]; then
+            echo "Connecting $FRONTEND_NAME:$PLUG to $RUNTIME_NAME:$SLOT"
+            # input from /dev/null prevents ssh from consuming the standard input
+            _run sudo snap connect $FRONTEND_NAME:$PLUG $RUNTIME_NAME:$SLOT < /dev/null
+        fi
+    done <<< "$FRONTEND_PLUGS"
+    # Collect unconnected frontend plugs and their corresponding (non-content) interface
+    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '$3 == "-" && $1 != "content" {print $2, $1}')
+    # Collect slots and their corresponding (non-content) interface
+    # and create an interface -> slot mapping (for quicker checks)
+    SLOTS=$(_run "snap connections --all" | awk '$3 ~ ":" && $1 != "content" {print $3, $1}')
+    declare -A INTERFACE_SLOT_MAP
+    while IFS=' ' read -r SLOT INTERFACE; do INTERFACE_SLOT_MAP[$INTERFACE]=$SLOT; done <<< "$SLOTS"
+    # For each unconnected frontend plug, check if you can connect to a matching runtime slot
+    while IFS=' ' read -r PLUG INTERFACE; do
+        SLOT=${INTERFACE_SLOT_MAP[$INTERFACE]}
+        if [ -n "$SLOT" ]; then
+            echo "Connecting $PLUG to $SLOT"
+            # input from /dev/null prevents ssh from consuming the standard input
+            _run sudo snap connect $PLUG $SLOT < /dev/null
+        fi
+    done <<< "$FRONTEND_PLUGS"
+}
+
 set -e
 
 if [[ "$#" != "3" ]]; then
@@ -69,8 +104,8 @@ log "Installing Checkbox snaps"
 export RISK=$1
 export FRONTEND_NAME=$2
 export FRONTEND_TRACK=$3
+export RUNTIME_NAME=$(get_runtime)
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
-RUNTIME_NAME=$(get_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"
@@ -96,31 +131,8 @@ _run sudo snap set $FRONTEND_NAME agent=enabled
 _run sudo snap set $FRONTEND_NAME slave=enabled
 
 if $STRICT_FRONTEND; then
-    # these are the default plugs (although some custom frontends may not have them)
-    CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
-    # these are the actual plugs for this frontend
-    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
-    # iterate over the default plugs...
-    for CONNECTION in $CONNECTIONS; do
-        # ... and connect them to the corresponding slot in the runtime, if the plug exists
-        if echo "$FRONTEND_PLUGS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
-            _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
-        fi
-    done
-
-    # these plugs are not automatically connected but are necessary to run some tests
-    # (we are handling results on a per-interface basis because we may not need
-    # these interfaces if we don't run the tests they are required for)
-    set +e
-    # network tests
-    _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service \
-    || echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
-    # bluetooth tests
-    _run sudo snap connect $FRONTEND_NAME:bluez bluez:service \
-    || echo "Failed to connect plug. Bluetooth tests may not work"
-    _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control \
-    || echo "Failed to connect plug. Bluetooth tests may not work"
-    set -e
+    # connect any unconnected frontend plugs to available plugs
+    connect
 fi
 
 # some versions of snapd seem to force dependencies to be stable in some situation

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -18,7 +18,7 @@
 
 set -e
 
-if [[ "$#" != "4" ]]; then
+if [[ "$#" != "3" ]]; then
   echo "Usage: $(basename ${BASH_SOURCE[0]}) risk frontend_name frontend_track"
   exit 1
 fi

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -96,4 +96,4 @@ export CHECKBOX_VERSION=$(_run $FRONTEND_NAME.checkbox-cli --version)
 echo "Installing checkbox $CHECKBOX_VERSION on the agent container from source"
 install_checkbox_agent_source $CHECKBOX_VERSION
 
-check_for_checkbox_service
+check_for_checkbox_service --debug

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -19,7 +19,8 @@
 
 get_ubuntu_arch() {
     declare -A arch_map=([x86_64]=amd64 [aarch64]=arm64 [armv7l]=armhf [i686]=i386)
-    echo "${arch_map[$(uname -m)]:-$(uname -m)}"
+    UNAME_ARCH=$(_run "uname -m")
+    echo "${arch_map[$UNAME_ARCH]:-$UNAME_ARCH}"
 }
 
 get_runtime() {

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -26,9 +26,12 @@ get_ubuntu_arch() {
 get_runtime() {
     # get the store token from the device, if available
     STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+    echo "DIAGNOSTIC store $STORE" 
     # get the snap info from the snap store and extract the base
     SNAPSTORE_URL="https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base"
+    echo "DIAGNOSTIC store url $SNAPSTORE_URL"
     SNAPINFO=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "$SNAPSTORE_URL")
+    echo "DIAGNOSTIC snap info $SNAPINFO" | jq
     BASE=$(jq -r \
       --arg FRONTEND_TRACK $FRONTEND_TRACK \
       --arg RISK $RISK \
@@ -41,6 +44,7 @@ get_runtime() {
         ) |
         .base' <<< $SNAPINFO
     )
+    echo "DIAGNOSTIC base $BASE"
     # use the base as a heuristic to derive the Checkbox runtime
     if [ "$BASE" = "null" ]; then
       # no base:" fall back to using the Core version

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -27,10 +27,20 @@ get_runtime() {
     # get the store token from the device, if available
     STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
     # get the snap info from the snap store and extract the base
-    BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
-    | jq -r \
-    --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
-    '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
+    SNAPSTORE_URL="https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base"
+    SNAPINFO=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "$SNAPSTORE_URL")
+    BASE=$(jq -r \
+      --arg FRONTEND_TRACK $FRONTEND_TRACK \
+      --arg RISK $RISK \
+      --arg ARCH $(get_ubuntu_arch) \
+      '.["channel-map"] | .[] |
+       select(
+         .channel.track == $FRONTEND_TRACK and
+         .channel.risk == $RISK and
+         .channel.architecture == $ARCH
+        ) |
+        .base' <<< $SNAPINFO
+    )
     # use the base as a heuristic to derive the Checkbox runtime
     if [ "$BASE" = "null" ]; then
       # no base:" fall back to using the Core version

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -48,7 +48,27 @@ RISK=$1
 FRONTEND_NAME=$2
 FRONTEND_TRACK=$3
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
-RUNTIME_NAME=$(find_runtime)
+
+# get the store token from the device, if available
+STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+# get the snap info from the snap store and extract the base
+BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+| jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
+
+echo "DIAGNOSTIC: BASE=$BASE"
+
+# use the base as a heuristic to derive the Checkbox runtime
+if [ "$BASE" = "core" ]; then
+  # base: core -> runtime: checkbox16
+  RUNTIME_NAME=checkbox16
+else
+  # base coreYY -> runtime checkboxYY
+  # (the final "grep ." will cause the command to fail if there's no match)
+  RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
+fi
+echo "DIAGNOSTIC: RUNTIME_NAME=$RUNTIME_NAME"
+
+# RUNTIME_NAME=$(find_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -63,38 +63,6 @@ FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 RUNTIME_NAME=$(get_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
-
-    echo "DIAGNOSTIC: $RUNTIME_NAME (from function)"
-
-    # get the store token from the device, if available
-    STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
-    echo "DIAGNOSTIC: STORE=$STORE"
-    curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base"
-
-    echo "DIAGNOSTIC: $FRONTEND_TRACK $RISK $(get_ubuntu_arch)"
-
-    # get the snap info from the snap store and extract the base
-    BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
-    | jq -r \
-    --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
-    '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
-    echo "DIAGNOSTIC: BASE=$BASE"
-    
-    # use the base as a heuristic to derive the Checkbox runtime
-    if [ "$BASE" = "null" ]; then
-      # no base:" fall back to using the Core version
-      # (the final "grep ." will cause the command to fail if there's no match)
-      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
-    elif [ "$BASE" = "core" ]; then
-      # base: core -> runtime: checkbox16
-      RUNTIME_NAME=checkbox16
-    else
-      # base coreYY -> runtime checkboxYY
-      # (the final "grep ." will cause the command to fail if there's no match)
-      RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
-    fi
-    echo "DIAGNOSTIC: $RUNTIME_NAME"
-
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"
 _run sudo snap install --no-wait $RUNTIME_NAME --channel=$RUNTIME_CHANNEL
 wait_for_snap_changes

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -51,6 +51,10 @@ FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 
 # get the store token from the device, if available
 STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+
+echo "DIAGNOSTIC: Store info $STORE"
+curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" 
+
 # get the snap info from the snap store and extract the base
 BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
 | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -65,7 +65,7 @@ connect() {
     RUNTIME_SLOTS=$(_run snap connections "$RUNTIME_NAME" | awk '$2 == "-" {print $3}' | sed -n "s/$RUNTIME_NAME:\(.*\)$/\1/p")
     declare -A RUNTIME_SLOT_SET
     for SLOT in $RUNTIME_SLOTS; do RUNTIME_SLOT_SET[$SLOT]=$SLOT; done
-    # For each unconnected frontend plug, check if you can connect to a matching runtime slot
+    # For each unconnected frontend plug, check if you can connect it to a matching runtime slot
     while read -r PLUG; do
         SLOT=${RUNTIME_SLOT_SET[$PLUG]}
         if [ -n "$SLOT" ]; then
@@ -81,7 +81,7 @@ connect() {
     SLOTS=$(_run "snap connections --all" | awk '$3 ~ ":" && $1 != "content" {print $3, $1}')
     declare -A INTERFACE_SLOT_MAP
     while IFS=' ' read -r SLOT INTERFACE; do INTERFACE_SLOT_MAP[$INTERFACE]=$SLOT; done <<< "$SLOTS"
-    # For each unconnected frontend plug, check if you can connect to a matching runtime slot
+    # For each unconnected frontend plug, check if you can connect it to a slot on a matching interface
     while IFS=' ' read -r PLUG INTERFACE; do
         SLOT=${INTERFACE_SLOT_MAP[$INTERFACE]}
         if [ -n "$SLOT" ]; then

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -68,13 +68,13 @@ curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "h
 BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base&architecture=$(get_ubuntu_arch)" \
 | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
 
-echo "DIAGNOSTIC: BASE=$BASE"
+echo "DIAGNOSTIC: --BASE=$BASE--"
 
 # use the base as a heuristic to derive the Checkbox runtime
 if [ "$BASE" = "null" ]; then
   # no base:" resort to using the Core version
   # (the final "grep ." will cause the command to fail if there's no match)
-  RUNTIME_NAME="checkbox$(cat /etc/os-release | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+  RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
 elif [ "$BASE" = "core" ]; then
   # base: core -> runtime: checkbox16
   RUNTIME_NAME=checkbox16

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -80,10 +80,13 @@ if $STRICT_FRONTEND; then
     CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
     # these are the actual plugs for this frontend
     FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
+    echo ">>> DEBUG: $FRONTEND_PLUGS"
     # iterate over the default plugs...
     for CONNECTION in $CONNECTIONS; do
+        echo ">>> DEBUG: Checking if plug $CONNECTION" exists"
         # ... and connect them to the corresponding slot in the runtime, if the plug exists
         if echo "$CONNECTIONS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
+            echo ">>> DEBUG: MATCH"
             _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
         fi
     done

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -80,13 +80,13 @@ if $STRICT_FRONTEND; then
     CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
     # these are the actual plugs for this frontend
     FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
-    echo ">>> DEBUG: $FRONTEND_PLUGS"
+    echo "DEBUG: $FRONTEND_PLUGS"
     # iterate over the default plugs...
     for CONNECTION in $CONNECTIONS; do
-        echo ">>> DEBUG: Checking if plug $CONNECTION" exists"
+        echo "DEBUG: Checking if plug $CONNECTION" exists"
         # ... and connect them to the corresponding slot in the runtime, if the plug exists
         if echo "$CONNECTIONS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
-            echo ">>> DEBUG: MATCH"
+            echo "DEBUG: MATCH"
             _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
         fi
     done

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -53,8 +53,10 @@ if [ "$?" -ne 0 ]; then
 fi
 wait_for_snap_changes
 
-# setting this flag is currently required for Checkbox to decide how to resume
+# run the configure hook of the frontend snap
 _run sudo snap set $FRONTEND_NAME agent=enabled
+# note: setting "slave" instead of "agent" has been deprecated but is still necessary for some snaps
+_run sudo snap set $FRONTEND_NAME slave=enabled
 
 # start the service
 _run sudo snap start $FRONTEND_NAME

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -22,26 +22,28 @@ get_ubuntu_arch() {
     echo "${arch_map[$(uname -m)]:-$(uname -m)}"
 }
 
-find_runtime() {
-  # get the store token from the device, if available
-  STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
-  # get the snap info from the snap store and extract the base
-  # (to be used as a heuristic for deriving the Checkbox runtime)
-  BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
-  | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
-  if [ "$BASE" = "null" ]; then
-    # no base:" resort to using the Core version
-    # (the final "grep ." will cause the command to fail if there's no match)
-    RUNTIME_NAME="checkbox$(cat /etc/os-release | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
-  elif [ "$BASE" = "core" ]; then
-    # base: core -> runtime: checkbox16
-    RUNTIME_NAME=checkbox16
-  else
-    # base coreYY -> runtime checkboxYY
-    # (the final "grep ." will cause the command to fail if there's no match)
-    RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
-  fi
-  echo $RUNTIME_NAME
+get_runtime() {
+    # get the store token from the device, if available
+    STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+    # get the snap info from the snap store and extract the base
+    BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+    | jq -r \
+    --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
+    '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
+    # use the base as a heuristic to derive the Checkbox runtime
+    if [ "$BASE" = "null" ]; then
+      # no base:" fall back to using the Core version
+      # (the final "grep ." will cause the command to fail if there's no match)
+      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+    elif [ "$BASE" = "core" ]; then
+      # base: core -> runtime: checkbox16
+      RUNTIME_NAME=checkbox16
+    else
+      # base coreYY -> runtime checkboxYY
+      # (the final "grep ." will cause the command to fail if there's no match)
+      RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
+    fi
+    echo $RUNTIME_NAME
 }
 
 set -e
@@ -53,41 +55,11 @@ fi
 
 echo "Installing Checkbox snaps"
 
-RISK=$1
-FRONTEND_NAME=$2
-FRONTEND_TRACK=$3
+export RISK=$1
+export FRONTEND_NAME=$2
+export FRONTEND_TRACK=$3
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
-
-# get the store token from the device, if available
-STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
-
-echo "DIAGNOSTIC: Store info $STORE"
-curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" 
-
-# get the snap info from the snap store and extract the base
-BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
-| jq -r \
---arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
-'.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
-
-echo "DIAGNOSTIC: --BASE=$BASE--"
-
-# use the base as a heuristic to derive the Checkbox runtime
-if [ "$BASE" = "null" ]; then
-  # no base:" resort to using the Core version
-  # (the final "grep ." will cause the command to fail if there's no match)
-  RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
-elif [ "$BASE" = "core" ]; then
-  # base: core -> runtime: checkbox16
-  RUNTIME_NAME=checkbox16
-else
-  # base coreYY -> runtime checkboxYY
-  # (the final "grep ." will cause the command to fail if there's no match)
-  RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
-fi
-echo "DIAGNOSTIC: RUNTIME_NAME=$RUNTIME_NAME"
-
-# RUNTIME_NAME=$(find_runtime)
+RUNTIME_NAME=$(find_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -60,13 +60,23 @@ _run sudo snap set $FRONTEND_NAME agent=enabled
 _run sudo snap start $FRONTEND_NAME
 
 if $STRICT_FRONTEND; then
-    # these plugs are not automatically connected but are necessary to run some
-    # tests. Namely:
-    set +e
-    # Here we are handling results on a per-interface basis because we may not need
-    # these interfaces as we may not need to run the tests they are needed for
+    # these are the default plugs (although some custom frontends may not have them)
+    CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
+    # these are the actual plugs for this frontend
+    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
+    # iterate over the default plugs...
+    for CONNECTION in $CONNECTIONS; do
+        # ... and connect them to the corresponding slot in the runtime, if the plug exists
+        if echo "$FRONTEND_PLUGS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
+            _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
+        fi
+    done
 
-    # Network tests
+    # these plugs are not automatically connected but are necessary to run some tests
+    # (we are handling results on a per-interface basis because we may not need
+    # these interfaces if we don't run the tests they are required for)
+    set +e
+    # network tests
     _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service \
     || echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
     # bluetooth tests
@@ -75,21 +85,6 @@ if $STRICT_FRONTEND; then
     _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control \
     || echo "Failed to connect plug. Bluetooth tests may not work"
     set -e
-
-    # these are the default plugs (although some custom frontends may not have them)
-    CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
-    # these are the actual plugs for this frontend
-    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
-    echo "DEBUG: $FRONTEND_PLUGS"
-    # iterate over the default plugs...
-    for CONNECTION in $CONNECTIONS; do
-        echo "DEBUG: Checking if plug $FRONTEND_NAME:$CONNECTION exists"
-        # ... and connect them to the corresponding slot in the runtime, if the plug exists
-        if echo "$FRONTEND_PLUGS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
-            echo "DEBUG: MATCH"
-            _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
-        fi
-    done
 fi
 
 # some versions of snapd seem to force dependencies to be stable in some situation

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -60,19 +60,13 @@ if $STRICT_FRONTEND; then
   # these interfaces as we may not need to run the tests they are needed for
 
   # Network tests
-  _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service
-  if [ $? -ne 0 ]; then
-    echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
-  fi
+  _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service \
+  || echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
   # bluetooth tests
-  _run sudo snap connect $FRONTEND_NAME:bluez bluez:service
-  if [ $? -ne 0 ]; then
-    echo "Failed to connect plug. Bluetooth tests may not work"
-  fi
-  _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control
-  if [ $? -ne 0 ]; then
-    echo "Failed to connect plug. Bluetooth tests may not work"
-  fi
+  _run sudo snap connect $FRONTEND_NAME:bluez bluez:service \
+  || echo "Failed to connect plug. Bluetooth tests may not work"
+  _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control \
+  || echo "Failed to connect plug. Bluetooth tests may not work"
   set -e
 
   # force connect also the default plugs. This is necessary on some machines but

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -51,6 +51,8 @@ fi
 
 _run sudo snap install --no-wait $FRONTEND_NAME $EXTRA_SNAP_INSTALL_FLAG --channel=$FRONTEND_TRACK/$RISK
 wait_for_snap_changes
+_run sudo snap set $FRONTEND_NAME agent=enabled
+_run sudo snap start $FRONTEND_NAME
 
 if $STRICT_FRONTEND; then
   # these plugs are not automatically connected but are necessary to run some
@@ -83,7 +85,9 @@ fi
 #       then this causes just 1 download
 _run sudo snap refresh --no-wait $RUNTIME_NAME --channel=latest/$RISK
 wait_for_snap_changes
-_run sudo snap restart $RUNTIME_NAME
+
+# restart the service to make sure the latest version of the code is used
+_run sudo snap restart $FRONTEND_NAME
 
 export CHECKBOX_VERSION=$(_run $FRONTEND_NAME.checkbox-cli --version)
 [ -z "$CHECKBOX_VERSION" ] && echo "Error: Unable to retrieve Checkbox version from device" && exit 1

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -83,6 +83,7 @@ fi
 #       then this causes just 1 download
 _run sudo snap refresh --no-wait $RUNTIME_NAME --channel=latest/$RISK
 wait_for_snap_changes
+_run sudo snap restart $RUNTIME_NAME
 
 export CHECKBOX_VERSION=$(_run $FRONTEND_NAME.checkbox-cli --version)
 [ -z "$CHECKBOX_VERSION" ] && echo "Error: Unable to retrieve Checkbox version from device" && exit 1

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -22,15 +22,18 @@ get_ubuntu_arch() {
     echo "${arch_map[$(uname -m)]:-$(uname -m)}"
 }
 
-
 find_runtime() {
   # get the store token from the device, if available
   STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
   # get the snap info from the snap store and extract the base
+  # (to be used as a heuristic for deriving the Checkbox runtime)
   BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
   | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
-  # use the base as a heuristic to derive the Checkbox runtime
-  if [ "$BASE" = "core" ]; then
+  if [ "$BASE" = "null" ]; then
+    # no base:" resort to using the Core version
+    # (the final "grep ." will cause the command to fail if there's no match)
+    RUNTIME_NAME="checkbox$(cat /etc/os-release | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+  elif [ "$BASE" = "core" ]; then
     # base: core -> runtime: checkbox16
     RUNTIME_NAME=checkbox16
   else
@@ -68,7 +71,11 @@ BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STO
 echo "DIAGNOSTIC: BASE=$BASE"
 
 # use the base as a heuristic to derive the Checkbox runtime
-if [ "$BASE" = "core" ]; then
+if [ "$BASE" = "null" ]; then
+  # no base:" resort to using the Core version
+  # (the final "grep ." will cause the command to fail if there's no match)
+  RUNTIME_NAME="checkbox$(cat /etc/os-release | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+elif [ "$BASE" = "core" ]; then
   # base: core -> runtime: checkbox16
   RUNTIME_NAME=checkbox16
 else

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -26,12 +26,9 @@ get_ubuntu_arch() {
 get_runtime() {
     # get the store token from the device, if available
     STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
-    echo "DIAGNOSTIC store $STORE" 
     # get the snap info from the snap store and extract the base
     SNAPSTORE_URL="https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base"
-    echo "DIAGNOSTIC store url $SNAPSTORE_URL"
     SNAPINFO=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "$SNAPSTORE_URL")
-    echo "DIAGNOSTIC snap info $SNAPINFO" | jq
     BASE=$(jq -r \
       --arg FRONTEND_TRACK $FRONTEND_TRACK \
       --arg RISK $RISK \
@@ -44,7 +41,6 @@ get_runtime() {
         ) |
         .base' <<< $SNAPINFO
     )
-    echo "DIAGNOSTIC base $BASE"
     # use the base as a heuristic to derive the Checkbox runtime
     if [ "$BASE" = "null" ]; then
       # no base:" fall back to using the Core version

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -16,6 +16,24 @@
 #   It is also used to appropriately install the snap (decide if a snap is
 #   classic or strict)
 
+
+find_runtime() {
+  # get the store token from the device, if available
+  STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+  # get the snap info from the snap store and extract the base
+  BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+  | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
+  # use the base as a heuristic to derive the Checkbox runtime
+  if [ "$BASE" = "core" ]; then
+    # base: core -> runtime: checkbox16
+    RUNTIME_NAME=checkbox16
+  else
+    # base coreYY -> runtime checkboxYY
+    # (the final "grep ." will cause the command to fail if there's no match)
+    RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
+  fi
+}
+
 set -e
 
 if [[ "$#" != "3" ]]; then
@@ -29,11 +47,7 @@ RISK=$1
 FRONTEND_NAME=$2
 FRONTEND_TRACK=$3
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
-
-# the runtime name is "checkboxYY";
-# YY is extracted from the "base" field of the frontend snap, which should be coreYY;
-# the final "grep ." will cause this script to exit if there's no match
-RUNTIME_NAME="checkbox$(_run "snap info --verbose $FRONTEND_NAME" | sed -n 's/^base:\s*core\([0-9]\{2\}\)$/\1/p' | grep .)"
+RUNTIME_NAME=$(find_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -62,6 +62,38 @@ FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 RUNTIME_NAME=$(get_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
+
+    echo "DIAGNOSTIC: $RUNTIME_NAME (from function)"
+
+    # get the store token from the device, if available
+    STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
+    echo "DIAGNOSTIC: STORE=$STORE"
+    curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base"
+
+    echo "DIAGNOSTIC: $FRONTEND_TRACK $RISK $(get_ubuntu_arch)"
+
+    # get the snap info from the snap store and extract the base
+    BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+    | jq -r \
+    --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
+    '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
+    echo "DIAGNOSTIC: BASE=$BASE"
+    
+    # use the base as a heuristic to derive the Checkbox runtime
+    if [ "$BASE" = "null" ]; then
+      # no base:" fall back to using the Core version
+      # (the final "grep ." will cause the command to fail if there's no match)
+      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+    elif [ "$BASE" = "core" ]; then
+      # base: core -> runtime: checkbox16
+      RUNTIME_NAME=checkbox16
+    else
+      # base coreYY -> runtime checkboxYY
+      # (the final "grep ." will cause the command to fail if there's no match)
+      RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
+    fi
+    echo "DIAGNOSTIC: $RUNTIME_NAME"
+
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"
 _run sudo snap install --no-wait $RUNTIME_NAME --channel=$RUNTIME_CHANNEL
 wait_for_snap_changes

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -33,7 +33,7 @@ FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 # the runtime name is "checkboxYY";
 # YY is extracted from the "base" field of the front-end snap, which should be coreYY;
 # the final "grep ." will cause this script to exit if there's no match
-RUNTIME_NAME="checkbox$(snap info --verbose $FRONTEND_NAME | sed -n 's/^base:\s*core\([0-9]\{2\}\)$/\1/p' | grep .)"
+RUNTIME_NAME="checkbox$(_run "snap info --verbose $FRONTEND_NAME" | sed -n 's/^base:\s*core\([0-9]\{2\}\)$/\1/p' | grep .)"
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -83,7 +83,7 @@ if $STRICT_FRONTEND; then
     echo "DEBUG: $FRONTEND_PLUGS"
     # iterate over the default plugs...
     for CONNECTION in $CONNECTIONS; do
-        echo "DEBUG: Checking if plug $CONNECTION" exists"
+        echo "DEBUG: Checking if plug $CONNECTION exists"
         # ... and connect them to the corresponding slot in the runtime, if the plug exists
         if echo "$CONNECTIONS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
             echo "DEBUG: MATCH"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -10,8 +10,6 @@
 # ready to run tests.
 # The `risk` parameter can be either "stable", "beta", "edge" and is used for
 #   both runtime and frontend
-# The `runtime_name` can be any of the runtime snaps (eg. checkbox16,
-#   checkbox24 etc.)
 # The `frontend_name` can be any of the frontend snaps (eg. checkbox,
 #   checkbox-tillamook).
 # The `frontend_track` parameter can be any valid track name (eg. 22.04, uc16).
@@ -21,19 +19,25 @@
 set -e
 
 if [[ "$#" != "4" ]]; then
-  echo "Usage: $(basename ${BASH_SOURCE[0]}) risk runtime_name frontend_name frontend_track"
+  echo "Usage: $(basename ${BASH_SOURCE[0]}) risk frontend_name frontend_track"
   exit 1
 fi
 
 echo "Installing Checkbox snaps"
 
 RISK=$1
-RUNTIME_NAME=$2
-FRONTEND_NAME=$3
-FRONTEND_TRACK=$4
+FRONTEND_NAME=$2
+FRONTEND_TRACK=$3
+FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
 
-wait_for_snap_changes
-_run sudo snap install --no-wait $RUNTIME_NAME --channel=latest/$RISK
+# the runtime name is "checkboxYY";
+# YY is extracted from the "base" field of the front-end snap, which should be coreYY;
+# the final "grep ." will cause this script to exit if there's no match
+RUNTIME_NAME="checkbox$(snap info --verbose $FRONTEND_NAME | sed -n 's/^base:\s*core\([0-9]\{2\}\)$/\1/p' | grep .)"
+RUNTIME_CHANNEL="latest/$RISK"
+
+echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"
+_run sudo snap install --no-wait $RUNTIME_NAME --channel=$RUNTIME_CHANNEL
 wait_for_snap_changes
 
 # strict snaps need a different install flag and the connections to be made.
@@ -42,14 +46,15 @@ wait_for_snap_changes
 [[ "$FRONTEND_TRACK" == uc* ]] && STRICT_FRONTEND=true || STRICT_FRONTEND=false
 
 if $STRICT_FRONTEND; then
-  echo "Frontend is a strict snap, using --devmode"
+  NOTE="strict snap, using --devmode"
   EXTRA_SNAP_INSTALL_FLAG="--devmode"
 else
-  echo "Frontend is a classic snap, using --classic"
+  NOTE="classic snap, using --classic"
   EXTRA_SNAP_INSTALL_FLAG="--classic"
 fi
 
-_run sudo snap install --no-wait $FRONTEND_NAME $EXTRA_SNAP_INSTALL_FLAG --channel=$FRONTEND_TRACK/$RISK
+echo "Installing front-end snap: $FRONTEND_NAME from $FRONTEND_CHANNEL ($NOTE)"
+_run sudo snap install --no-wait $FRONTEND_NAME $EXTRA_SNAP_INSTALL_FLAG --channel=$FRONTEND_CHANNEL
 wait_for_snap_changes
 _run sudo snap set $FRONTEND_NAME agent=enabled
 _run sudo snap start $FRONTEND_NAME

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -60,28 +60,33 @@ _run sudo snap set $FRONTEND_NAME agent=enabled
 _run sudo snap start $FRONTEND_NAME
 
 if $STRICT_FRONTEND; then
-  # these plugs are not automatically connected but are necessary to run some
-  # tests. Namely:
-  set +e
-  # Here we are handling results on a per-interface basis because we may not need
-  # these interfaces as we may not need to run the tests they are needed for
+    # these plugs are not automatically connected but are necessary to run some
+    # tests. Namely:
+    set +e
+    # Here we are handling results on a per-interface basis because we may not need
+    # these interfaces as we may not need to run the tests they are needed for
 
-  # Network tests
-  _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service \
-  || echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
-  # bluetooth tests
-  _run sudo snap connect $FRONTEND_NAME:bluez bluez:service \
-  || echo "Failed to connect plug. Bluetooth tests may not work"
-  _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control \
-  || echo "Failed to connect plug. Bluetooth tests may not work"
-  set -e
+    # Network tests
+    _run sudo snap connect $FRONTEND_NAME:network-manager network-manager:service \
+    || echo "Failed to connect plug. Networking (mostly wifi) tests may not work"
+    # bluetooth tests
+    _run sudo snap connect $FRONTEND_NAME:bluez bluez:service \
+    || echo "Failed to connect plug. Bluetooth tests may not work"
+    _run sudo snap connect $FRONTEND_NAME:bluetooth-control core:bluetooth-control \
+    || echo "Failed to connect plug. Bluetooth tests may not work"
+    set -e
 
-  # force connect also the default plugs. This is necessary on some machines but
-  # is effectively a no-op when it would not be needed
-  _run sudo snap connect $FRONTEND_NAME:checkbox-runtime $RUNTIME_NAME:checkbox-runtime
-  _run sudo snap connect $FRONTEND_NAME:provider-certification-client $RUNTIME_NAME:provider-certification-client
-  _run sudo snap connect $FRONTEND_NAME:provider-checkbox $RUNTIME_NAME:provider-checkbox
-  _run sudo snap connect $FRONTEND_NAME:provider-resource $RUNTIME_NAME:provider-resource
+    # these are the default plugs (although some custom frontends may not have them)
+    CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"
+    # these are the actual plugs for this frontend
+    FRONTEND_PLUGS=$(_run "snap connections $FRONTEND_NAME" | awk '{ print $2 }' | tail +2)
+    # iterate over the default plugs...
+    for CONNECTION in $CONNECTIONS; do
+        # ... and connect them to the corresponding slot in the runtime, if the plug exists
+        if echo "$CONNECTIONS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
+            _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
+        fi
+    done
 fi
 
 # some versions of snapd seem to force dependencies to be stable in some situation

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -83,9 +83,9 @@ if $STRICT_FRONTEND; then
     echo "DEBUG: $FRONTEND_PLUGS"
     # iterate over the default plugs...
     for CONNECTION in $CONNECTIONS; do
-        echo "DEBUG: Checking if plug $CONNECTION exists"
+        echo "DEBUG: Checking if plug $FRONTEND_NAME:$CONNECTION exists"
         # ... and connect them to the corresponding slot in the runtime, if the plug exists
-        if echo "$CONNECTIONS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
+        if echo "$FRONTEND_PLUGS" | grep -q "^$FRONTEND_NAME:$CONNECTION$"; then
             echo "DEBUG: MATCH"
             _run sudo snap connect $FRONTEND_NAME:$CONNECTION $RUNTIME_NAME:$CONNECTION
         fi

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -59,7 +59,7 @@ export RISK=$1
 export FRONTEND_NAME=$2
 export FRONTEND_TRACK=$3
 FRONTEND_CHANNEL="$FRONTEND_TRACK/$RISK"
-RUNTIME_NAME=$(find_runtime)
+RUNTIME_NAME=$(get_runtime)
 RUNTIME_CHANNEL="latest/$RISK"
 
 echo "Installing runtime snap: $RUNTIME_NAME from $RUNTIME_CHANNEL"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -65,8 +65,10 @@ echo "DIAGNOSTIC: Store info $STORE"
 curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" 
 
 # get the snap info from the snap store and extract the base
-BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base&architecture=$(get_ubuntu_arch)" \
-| jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
+BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+| jq -r \
+--arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK --arg ARCH $(get_ubuntu_arch) \
+'.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK and .channel.architecture == $ARCH) | .base')
 
 echo "DIAGNOSTIC: --BASE=$BASE--"
 

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -85,9 +85,6 @@ _run sudo snap set $FRONTEND_NAME agent=enabled
 # note: setting "slave" instead of "agent" has been deprecated but is still necessary for some snaps
 _run sudo snap set $FRONTEND_NAME slave=enabled
 
-# start the service
-_run sudo snap start $FRONTEND_NAME
-
 if $STRICT_FRONTEND; then
     # these are the default plugs (although some custom frontends may not have them)
     CONNECTIONS="checkbox-runtime provider-checkbox provider-resource provider-certification-client"

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -32,6 +32,7 @@ find_runtime() {
     # (the final "grep ." will cause the command to fail if there's no match)
     RUNTIME_NAME="checkbox$(echo $BASE | sed -n 's/^core\([0-9]\{2\}\)$/\1/p' | grep .)"
   fi
+  echo $RUNTIME_NAME
 }
 
 set -e

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -17,6 +17,12 @@
 #   classic or strict)
 
 
+get_ubuntu_arch() {
+    declare -A arch_map=([x86_64]=amd64 [aarch64]=arm64 [armv7l]=armhf [i686]=i386)
+    echo "${arch_map[$(uname -m)]:-$(uname -m)}"
+}
+
+
 find_runtime() {
   # get the store token from the device, if available
   STORE=$(_run "snap model --assertion" | sed -n 's/^store:\s\(.*\)$/\1/p')
@@ -56,7 +62,7 @@ echo "DIAGNOSTIC: Store info $STORE"
 curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" 
 
 # get the snap info from the snap store and extract the base
-BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base" \
+BASE=$(curl -s -H 'Snap-Device-Series: 16' ${STORE:+ -H "Snap-Device-Store: $STORE"} "https://api.snapcraft.io/v2/snaps/info/$FRONTEND_NAME?fields=base&architecture=$(get_ubuntu_arch)" \
 | jq -r --arg FRONTEND_TRACK $FRONTEND_TRACK --arg RISK $RISK '.["channel-map"] | .[] | select(.channel.track == $FRONTEND_TRACK and .channel.risk == $RISK) | .base')
 
 echo "DIAGNOSTIC: BASE=$BASE"


### PR DESCRIPTION
This PR primarily modifies the following scriptlets:
- `install_checkbox_snaps`
  - The name of the Checkbox runtime snap is no longer provided as an argument to the script but rather determined by the script itself, using the `base` of the frontend snap as a heuristic and falling back on the Core version when that `base` is not available.
  - The frontend Checkbox snap is installed in `--devmode` by default, falling back to installing in `--classic` mode if an error occurs.
  - Some default plugs (such as `provider-certification-client`) are not available on all custom Checkbox versions, so the script now installs them conditionally, i.e. after checking that it should.
- `clean_machine`
    - The script determines if package handling is available on the device (e.g. it is not available on Core systems) and only performs package-handling operations conditionally.
    - Some additional cleaning up of providers is performed and all cleaning up is performed using `sudo`, as permission problems were encountered on some systems during testing.

The modifications were made in the context of [RTW-399](https://warthogs.atlassian.net/browse/RTW-399), so that these scriptlets could be used for the snap-testing Jenkins jobs. Additional information (and tests) can be found in the [companion PR](https://github.com/canonical/hwcert-jenkins-jobs/pull/618) in the jobs repo.

[RTW-399]: https://warthogs.atlassian.net/browse/RTW-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ