### PR TITLE
Checkbox-provider-gpgpu is now amd64 only.

### DIFF
--- a/version-published/checkbox-canary.yaml
+++ b/version-published/checkbox-canary.yaml
@@ -65,7 +65,7 @@ required-packages:
     source: checkbox-provider-gpgpu
     package: checkbox-provider-gpgpu
     versions: [ "18.04", "20.04", "22.04", "24.04" ]
-    architectures: [ all ]
+    architectures: [ amd64 ]
 
   - channel: edge
     source: checkbox-provider-resource


### PR DESCRIPTION
Resolves CHECKBOX-1519

checkbox-provider-gpgpu is now `amd64` only. It really only ever worked for `amd64`, this just makes it official.

See: https://github.com/canonical/checkbox/pull/1542