### PR TITLE
Add: scp scriplets

### DIFF
--- a/scriptlets/_get_zapper
+++ b/scriptlets/_get_zapper
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Transfer files from a remote Zapper via SCP.
+#
+# Description:
+#
+# The IP of the device is provided by the environment variable ZAPPER_IP,
+# which must be set. The user credentials on the remote device is `ubuntu:insecure`
+# by default, unless provided by the environment variables ZAPPER_USER and ZAPPER_PWD.
+#
+# The last argument provided is considered to be the "target", i.e. where
+# on the local device the file(s) will be copied.
+#
+# The source(s) can start with `:` (as is also the case with programs like
+# `scp`) to explicitly denote a source on the remote device. 
+#
+# This script sources `defs/set_ssh_options` to set SSH_OPTS.
+# This script soures `defs/check_for_zapper_ip` to check that ZAPPER_IP is set.
+#
+# Return value:
+#
+# 0 if the copy operation is successful or >0 in case of an error.
+
+usage() {
+    echo "Usage: $(basename ${BASH_SOURCE[0]}) [:<source>]+ <target>"
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    echo "Error: <source> and/or <target> not specified"
+    exit 1
+fi
+
+source "$(dirname ${BASH_SOURCE[0]})/check_for_zapper_ip"
+source "$(dirname ${BASH_SOURCE[0]})/defs/ssh_options"
+
+# The target is the last argument
+TARGET=${@: -1}
+
+# Extract the sources (remove the target) from the argument list...
+SOURCES_ARRAY=("${@:1:$#-1}")
+# ... and prefix them appropriately
+PREFIX=${ZAPPER_USER:-ubuntu}@${ZAPPER_IP}
+SOURCES=()
+for SOURCE in "${SOURCES_ARRAY[@]}"; do
+    [[ ${SOURCE:0:1} != ":" ]] && SOURCE=":${SOURCE}"
+    SOURCES+=("${PREFIX}${SOURCE}")
+done
+SOURCES="${SOURCES[@]}"
+
+sshpass -p ${ZAPPER_PWD:-insecure} scp $SSH_OPTS $SOURCES $TARGET

--- a/scriptlets/_put_zapper
+++ b/scriptlets/_put_zapper
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Transfer files to a remote Zapper via SCP.
+#
+# Description:
+#
+# The IP of the device is provided by the environment variable ZAPPER_IP,
+# which must be set. The user credentials on the remote device is `ubuntu:insecure`
+# by default, unless provided by the environment variables ZAPPER_USER and ZAPPER_PWD.
+#
+# The last argument provided is considered to be the "target", i.e. where
+# on the remote device the file(s) will be copied.
+#
+# The target can start with `:` (as is also the case with programs like `scp`)
+# to explicitly denote a destination on the remote device. If the last argument
+# is a plain `:`, then the file(s) will be copied to the home directory of
+# ZAPPER_USER.
+#
+# This script sources `defs/set_ssh_options` to set SSH_OPTS.
+# This script soures `defs/check_for_zapper_ip` to check that ZAPPER_IP is set.
+#
+# Return value:
+#
+# 0 if the copy operation is successful or >0 in case of an error.
+
+usage() {
+    echo "Usage: $(basename ${BASH_SOURCE[0]}) <source> ... :[<target>]"
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    echo "Error: <source> and/or <target> not specified"
+    exit 1
+fi
+
+source "$(dirname ${BASH_SOURCE[0]})/check_for_zapper_ip"
+source "$(dirname ${BASH_SOURCE[0]})/defs/ssh_options"
+
+# The target is the last argument (prefixed appropriately)
+PREFIX=${ZAPPER_USER:-ubuntu}@${ZAPPER_IP}
+TARGET=${@: -1}
+[[ "${TARGET:0:1}" != ":" ]] && TARGET=":${TARGET}"
+TARGET=${PREFIX}${TARGET}
+
+# Extract the sources (remove the target) from the argument list
+SOURCES_ARRAY=("${@:1:$#-1}")
+SOURCES="${SOURCES_ARRAY[@]}"
+
+sshpass -p ${ZAPPER_PWD:-insecure} scp $SSH_OPTS $SOURCES $TARGET


### PR DESCRIPTION
This PR adds the `put`/`get` scriplets. Useful in CI when sideloading content or any other necessary asset.

Tested with https://testflinger.canonical.com/jobs/ece65f9a-1240-4444-8a5b-69f0dc85e763