### PR TITLE
Change: option to skip instaling tools on device

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -3,7 +3,7 @@
 # Clone the certification tools repo to a local directory.
 # If the repo is already available locally, fetch the latest version.
 # Use the --branch option to specify a specific branch.
-# Use the --skip-dut to skip installing scriptlets to the DUT.
+# Use the --skip-device to skip installing scriptlets to the DUT.
 
 # disable tracing (if previously enabled)
 [[ "$-" == *x* ]] && TRACING=true && set +x || TRACING=false
@@ -14,7 +14,7 @@ TOOLS_PATH_DEFAULT=$(basename $TOOLS_REPO .git)
 export TOOLS_PATH_DEVICE=".scriptlets"
 
 usage() {
-    echo "Usage: $0 [<path>] [--branch <value>] [--skip-dut]"
+    echo "Usage: $0 [<path>] [--branch <value>] [--skip-device]"
     exit 1
 }
 
@@ -54,7 +54,7 @@ while [[ "$#" -gt 0 ]]; do
                 exit 1
             fi
             ;;
-        --skip-dut)
+        --skip-device)
             SKIP_DEVICE=true
             ;;
         *)

--- a/install_tools.sh
+++ b/install_tools.sh
@@ -3,7 +3,7 @@
 # Clone the certification tools repo to a local directory.
 # If the repo is already available locally, fetch the latest version.
 # Use the --branch option to specify a specific branch.
-# Use the --skip-device to skip installing scriptlets to the DUT.
+# Use the --skip-device option to skip installing scriptlets to the DUT.
 
 # disable tracing (if previously enabled)
 [[ "$-" == *x* ]] && TRACING=true && set +x || TRACING=false

--- a/install_tools.sh
+++ b/install_tools.sh
@@ -41,6 +41,7 @@ install_on_device() {
 
 TOOLS_PATH=""
 BRANCH=""
+SKIP_DEVICE=""
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --branch)
@@ -51,6 +52,9 @@ while [[ "$#" -gt 0 ]]; do
                 echo "Error: value required for --branch"
                 exit 1
             fi
+            ;;
+        --skip-dut)
+            SKIP_DEVICE=true
             ;;
         *)
             if [ -z "$TOOLS_PATH" ]; then
@@ -78,12 +82,14 @@ add_to_path $SCRIPTLETS_PATH
 add_to_path $SCRIPTLETS_PATH/sru-helpers
 add_to_path ~/.local/bin
 
-# ensure that the device is reachable and copy over selected scriptlets
-# (testing reachability with --allow-starting is a single-try fallback option)
-(wait_for_ssh --allow-degraded || check_for_ssh --allow-starting) \
-&& echo "Installing selected scriptlets on the device" \
-&& install_on_device \
-|| exit 1
+if [ -z "$SKIP_DEVICE" ]; then
+    # ensure that the device is reachable and copy over selected scriptlets
+    # (testing reachability with --allow-starting is a single-try fallback option)
+    (wait_for_ssh --allow-degraded || check_for_ssh --allow-starting) \
+    && echo "Installing selected scriptlets on the device" \
+    && install_on_device \
+    || exit 1
+fi
 
 echo "Installing agent dependencies"
 install_packages pipx python3-venv sshpass jq > /dev/null

--- a/install_tools.sh
+++ b/install_tools.sh
@@ -2,7 +2,8 @@
 
 # Clone the certification tools repo to a local directory.
 # If the repo is already available locally, fetch the latest version.
-# Use the --branch option to specify a specific branch
+# Use the --branch option to specify a specific branch.
+# Use the --skip-dut to skip installing scriptlets to the DUT.
 
 # disable tracing (if previously enabled)
 [[ "$-" == *x* ]] && TRACING=true && set +x || TRACING=false
@@ -13,7 +14,7 @@ TOOLS_PATH_DEFAULT=$(basename $TOOLS_REPO .git)
 export TOOLS_PATH_DEVICE=".scriptlets"
 
 usage() {
-    echo "Usage: $0 [<path>] [--branch <value>]"
+    echo "Usage: $0 [<path>] [--branch <value>] [--skip-dut]"
     exit 1
 }
 


### PR DESCRIPTION
This PR adds the possibility to not install anything on the DUT, using the `--skip-dut` switch. This is useful when the DUT might be unreachable via SSH, and we plan to interact with it using a support machine.

Tests
1. Default: testflinger.canonical.com/jobs/67d63df5-d0ac-4cfa-96b1-6ade62502d88
2. With `--skip-dut`: testflinger.canonical.com/jobs/95e8639c-72b2-4bd0-8611-e0abe58be865