### PR TITLE
Change the snap rerun URL

### DIFF
--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -81,12 +81,13 @@ class Main:
 
     def _submit_snap_rerun(self, base_job_link: str) -> None:
         rerun_link = f"{base_job_link}/buildWithParameters"
-        logging.info(f"POST {rerun_link}")
-        requests.post(rerun_link, auth=self.jenkins_auth)
+        data = {"TEST_OBSERVER_REPORTING": True}
+        logging.info(f"POST {rerun_link} {data}")
+        requests.post(rerun_link, auth=self.jenkins_auth, json=data)
 
     def _submit_deb_rerun(self, base_job_link: str) -> None:
         rerun_link = f"{base_job_link}/buildWithParameters"
-        data = {"TESTPLAN": "full"}
+        data = {"TESTPLAN": "full", "TEST_OBSERVER_REPORTING": True}
         logging.info(f"POST {rerun_link} {data}")
         requests.post(rerun_link, auth=self.jenkins_auth, json=data)
 

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -80,7 +80,7 @@ class Main:
         return None
 
     def _submit_snap_rerun(self, base_job_link: str) -> None:
-        rerun_link = f"{base_job_link}/build"
+        rerun_link = f"{base_job_link}/buildWithParameters"
         logging.info(f"POST {rerun_link}")
         requests.post(rerun_link, auth=self.jenkins_auth)
 

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -27,7 +27,7 @@ def test_correctly_submits_deb_rerun_request(requests_mock: Mocker):
     )
 
     def are_build_parameters_valid(request) -> bool:  # noqa: ANN001
-        return request.json() == {"TESTPLAN": "full"}
+        return request.json() == {"TESTPLAN": "full", "TEST_OBSERVER_REPORTING": True}
 
     rerun_link = f"{job_link}/buildWithParameters"
     jenkins_build_matcher = requests_mock.post(
@@ -59,10 +59,14 @@ def test_correctly_submits_snap_rerun_request(requests_mock: Mocker):
         json=[{"test_execution_id": 1, "ci_link": ci_link, "family": "snap"}],
     )
 
+    def are_build_parameters_valid(request) -> bool:  # noqa: ANN001
+        return request.json() == {"TEST_OBSERVER_REPORTING": True}
+
     rerun_link = f"{job_link}/buildWithParameters"
     jenkins_build_matcher = requests_mock.post(
         rerun_link,
         request_headers=jenkins_request_headers,
+        additional_matcher=are_build_parameters_valid,
     )
 
     def is_delete_body_valid(request) -> bool:

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -59,7 +59,7 @@ def test_correctly_submits_snap_rerun_request(requests_mock: Mocker):
         json=[{"test_execution_id": 1, "ci_link": ci_link, "family": "snap"}],
     )
 
-    rerun_link = f"{job_link}/build"
+    rerun_link = f"{job_link}/buildWithParameters"
     jenkins_build_matcher = requests_mock.post(
         rerun_link,
         request_headers=jenkins_request_headers,


### PR DESCRIPTION
After adding the parameter to decide whether to report snap testing jobs to Test Observer or not, we need to update the snap rerunner to include the parameters.

This change modifies the URL used to the alternative with parameters.