### PR TITLE
Fix: fallback to checkbox --classic

### DIFF
--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -119,10 +119,10 @@ STRICT_FRONTEND=true
 
 set +e
 _run sudo snap install --no-wait $FRONTEND_NAME --devmode --channel=$FRONTEND_CHANNEL
-snap_install_status=$?
+SNAP_INSTALL_STATUS=$?
 set -e
 
-if [ "$snap_install_status" -ne 0 ]; then
+if [ "$SNAP_INSTALL_STATUS" -ne 0 ]; then
     echo "Failed to install $FRONTEND_NAME as a strict snap"
     echo "Installing frontend snap: $FRONTEND_NAME from $FRONTEND_CHANNEL (as a classic snap, using --classic)"
     STRICT_FRONTEND=false

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -116,8 +116,13 @@ wait_for_snap_changes
 # (strict snaps need a different install flag and the connections to be made)
 echo "Installing frontend snap: $FRONTEND_NAME from $FRONTEND_CHANNEL (as a strict snap, using --devmode)"
 STRICT_FRONTEND=true
+
+set +e
 _run sudo snap install --no-wait $FRONTEND_NAME --devmode --channel=$FRONTEND_CHANNEL
-if [ "$?" -ne 0 ]; then
+snap_install_status=$?
+set -e
+
+if [ "$snap_install_status" -ne 0 ]; then
     echo "Failed to install $FRONTEND_NAME as a strict snap"
     echo "Installing frontend snap: $FRONTEND_NAME from $FRONTEND_CHANNEL (as a classic snap, using --classic)"
     STRICT_FRONTEND=false


### PR DESCRIPTION
Due to `set -e` at the start of the block, the `install_checkbox_snaps` scriplets fails to fallback to checkbox --classic when --devmode is not possible.

This PR temporarily set `set +e` when trying to install the snap in devmode.