### PR TITLE
[RTW-449] feat: add log-cleaning to `clean_machine`

### DIFF
--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -22,7 +22,7 @@ set +e
 
 # remove all kernel (dmesg) and journal logs
 sudo dmesg -C
-sudo journalctl --rotate && sudo journalctl --vacuum-time=1s
+sudo journalctl --rotate --vacuum-time=1s
 
 # delete all checkbox snaps, this includes any frontend or custom frontend
 # (they all contain checkbox in their name). This should also purge any

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -22,7 +22,7 @@ set +e
 
 # remove all kernel (dmesg) and journal logs
 sudo dmesg -C
-sudo journalctl --rotate --vacuum-time=1s
+sudo journalctl --rotate && sudo journalctl --vacuum-time=1s
 
 # delete all checkbox snaps, this includes any frontend or custom frontend
 # (they all contain checkbox in their name). This should also purge any

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -20,6 +20,10 @@ fi
 
 set +e
 
+# remove all kernel (dmesg) and journal logs
+sudo dmesg -C
+sudo journalctl --rotate && sudo journalctl --vacuum-time=1s
+
 # delete all checkbox snaps, this includes any frontend or custom frontend
 # (they all contain checkbox in their name). This should also purge any
 # running checkbox*agent service

--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -77,7 +77,7 @@ fi
 
 # Also remove any cloned version of Checkbox in any home, as this will clash
 # with anything trying to provision from source
-CHECKBOX_SOURCE_CLONES=$(find /home/ -maxdepth 2 -name "*checkbox*" -type d)
+CHECKBOX_SOURCE_CLONES=$(find $HOME -maxdepth 1 -name "*checkbox*" -type d)
 if [ -n "$CHECKBOX_SOURCE_CLONES" ]; then
   echo "Removing all clones of Checkbox on the machine"
   echo "Removing the following clones:"

--- a/scriptlets/log
+++ b/scriptlets/log
@@ -2,8 +2,10 @@
 
 if [ "$1" = "--warn" ]; then
     TAG=WARN
+    shift
 elif [ "$1" = "--error" ]; then
     TAG=ERROR
+    shift
 else
     TAG=INFO
 fi


### PR DESCRIPTION
## Description

From RTW-449:

> One common regression that we see is that a test assumes that, by querying the journal, it is able to understand if a regression happened (for example in the iwifi microcode crash). This is tricky on noprovision machines, as the regression may be from a precedent run. Similarly, when providing dmesg (or collecting dmesg) output, one can easily provide the wrong one on noprovision.

This PR introduces a code block at the beginning of the `clean_machine` scriptlet that clears the kernel ring buffer and the journal. Note that it does _not_ explicitly clear any files in `/var/log`, e.g. `/var/log/dmesg`.

As an aside:
- a minor issue with the way that `clean_machine` removes Checkbox directories is also addressed (it only attempts to do so under the current user's home directory, to avoid permission errors.
- a minor bug in the `log` scriptlet is addressed.

## Issue

Resolves [RTW-449](https://warthogs.atlassian.net/browse/RTW-449).

## Tests

A Testflinger job file was created with the following `test_cmds`:
```
# retrieve all scripts/tools necessary from a repo
export TOOLS_PATH=tools
curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
source install_tools.sh --branch RTW-449-clean-machine-logs $TOOLS_PATH > /dev/null 2>&1

# create a Checkbox folder
_run mkdir checkbox

# write specific message to log
_run "echo TEST_MESSAGE | sudo tee /dev/kmsg"

# show that the message is contained in the dmesg and the journal
_run sudo dmesg | grep -q "TEST_MESSAGE" && log "message originally in dmesg" || log --error "message not in dmesg!"
_run sudo journalctl | grep -q "TEST_MESSAGE" && log "message originally in journal" || log --error "message not in journal!"

# clean the DUT; this is exactly how jobs will start
_run clean_machine --im-sure

# show that the Checkbox folder has been cleared 
_run find $HOME -maxdepth 1 -name "*checkbox*" -type d | grep -q . && log --error "checkbox not cleared!" || log "checkbox clear"

# show that the message is not contained in the dmesg and the journal
_run sudo dmesg | grep -q "TEST_MESSAGE" && log --error "dmesg not cleared!" || log "dmesg clear"
_run sudo journalctl | grep -q "TEST_MESSAGE" && log --error "journal not cleared" || log "journal clear"
```

This job was submitted to Testflinger three times, to different queues and using different provisioning data:
- queue `jollyville`, provisioned with `distro: core20-latest-stable` [[job](https://testflinger.canonical.com/jobs/419cb5ea-d073-4832-9e42-6449420e411c)]
- queue `202004-27812` (precision-7750-c1), provisioned with `distro: desktop-18-04-5-curtinator-uefi` [[job](854f3926-84b9-40a1-9a50-1d7ef2030d35)]
- queue `202102-28727` (z2-sff-g8-workstation-28727), provisioned with `distro: desktop-24-04-uefi` [[job](https://testflinger.canonical.com/jobs/1e88a129-da0a-438e-99c9-b804f4cdf3d0)]


[RTW-449]: https://warthogs.atlassian.net/browse/RTW-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ