### PR TITLE
(DRAFT) Change: update only mainboard

### DIFF
--- a/scriptlets/refresh_zapper_if_needed
+++ b/scriptlets/refresh_zapper_if_needed
@@ -38,10 +38,7 @@ if echo "$message" | grep -q 'no updates available'; then
     echo "Snap was up-to-date, restarting the service instead..."
     _run sudo snap restart zapper
 fi
-wait_for_zapper_addons
 
-message=$(_run zapper firmware update -y --allow-older)
-if echo "$message" | grep -q 'update in progress'; then
-    echo "Firmware(s) got upgraded, waiting again for the add-on discovery..."
-    wait_for_zapper_addons
-fi
+# Update only the mainboard firmware. The add-on firmware is rarely updated,  
+# and it's safer to do it manually for the time being.
+_run zapper firmware update -y --allow-older --component-type MAINBOARD


### PR DESCRIPTION
Updating add-ons every time seems to be an overkill: we rarely update it w/o bringing new functionalities to existing add-ons. I think for now that artifact shouldn't be part of the validation workflow.