### PR TITLE
fix: determine checkbox runtime

### DIFF
--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -44,12 +44,8 @@ get_runtime() {
         .base' <<< $SNAPINFO
     )
     # use the base as a heuristic to derive the Checkbox runtime
-    if [ "$BASE" = "null" ]; then
-      # no base: fall back to using the Ubuntu version
-      # (the final "grep ." will cause the command to fail if there's no match)
-      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/VERSION="\([0-9]\{2\}\).*"$/\1/p' | grep .)"
-    elif [ "$BASE" = "core" ]; then
-      # base: core -> runtime: checkbox16
+    if [ "$BASE" = "core" ] || [ "$BASE" = "null" ]; then
+      # base: core or undefined -> runtime: checkbox16
       RUNTIME_NAME=checkbox16
     else
       # base coreYY -> runtime checkboxYY

--- a/scriptlets/install_checkbox_snaps
+++ b/scriptlets/install_checkbox_snaps
@@ -45,9 +45,9 @@ get_runtime() {
     )
     # use the base as a heuristic to derive the Checkbox runtime
     if [ "$BASE" = "null" ]; then
-      # no base:" fall back to using the Core version
+      # no base: fall back to using the Ubuntu version
       # (the final "grep ." will cause the command to fail if there's no match)
-      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/PRETTY_NAME="Ubuntu Core \([0-9]\{2\}\)"$/\1/p' | grep .)"
+      RUNTIME_NAME="checkbox$(_run "cat /etc/os-release" | sed -n 's/VERSION="\([0-9]\{2\}\).*"$/\1/p' | grep .)"
     elif [ "$BASE" = "core" ]; then
       # base: core -> runtime: checkbox16
       RUNTIME_NAME=checkbox16


### PR DESCRIPTION
## Description

The `install_checkbox_snaps` scriptlet contains a `get_runtime` function that tries to determine the Checkbox runtime from the Checkbox frontend. When the base of the frontend is unspecified, the current implementation uses a flawed heuristic to determine the runtime. Instead, the default Checkbox runtime should _always_ be `checkbox16`.

## Tests

Install the `checkbox` frontend from `latest/beta` on an Ubuntu Core 24 system:
```
job_queue: rpi5b8g
provision_data:
  url: http://cdimage.ubuntu.com/ubuntu-core/24/dangerous-stable/pending/ubuntu-core-24-arm64+raspi.img.xz
test_data:
  test_cmds: |
    export TOOLS_PATH=tools
    curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
    source install_tools.sh --branch fix-get-checkbox-runtime $TOOLS_PATH
    install_checkbox_snaps beta checkbox latest
```
Excerpt from log:
```
2025-03-10 18:12:20 [INFO]: Installing Checkbox snaps
Installing runtime snap: checkbox22 from latest/beta
Installing frontend snap: checkbox from latest/beta (as a strict snap, using --devmode)
error: This revision of snap "checkbox.snap" was published using classic confinement...
Installing frontend snap: checkbox from latest/beta (as a classic snap, using --classic)
```

Install the `checkbox-extra` frontend from `uc16/edge` on an Ubuntu 24.04 system:
```
job_queue: hp-z2-sff-g8-workstation
provision_data:
  distro: desktop-24-04-uefi
test_data:
  test_cmds: |
    export TOOLS_PATH=tools
    curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
    source install_tools.sh --branch fix-get-checkbox-runtime $TOOLS_PATH

    export UBUNTU_STORE_AUTH=***
    install_checkbox_snaps edge checkbox-extra uc16
```

Excerpt from log:
```
2025-03-10 18:12:39 [INFO]: Installing Checkbox snaps
Installing runtime snap: checkbox16 from latest/edge
Installing frontend snap: checkbox-extra from uc16/edge (as a strict snap, using --devmode)
```