### PR TITLE
Fix test executions rerunner

### DIFF
--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -154,6 +154,11 @@ class JenkinsProcessor(RequestProcessor):
                 f"{cls.__name__} cannot find ci_link "
                 f"in rerun request {rerun_request}"
             ) from error
+        if not ci_link:
+            raise RequestProccesingError(
+                f"{cls.__name__} empty ci_link "
+                f"in rerun request {rerun_request}"
+            )
         # extract the rerun URL from the ci_link
         url = cls.extract_rerun_url_from_ci_link(ci_link)
         # determine additional payload arguments
@@ -233,6 +238,11 @@ class GithubProcessor(RequestProcessor):
                 f"{cls.__name__} cannot find ci_link "
                 f"in rerun request {rerun_request}"
             ) from error
+        if not ci_link:
+            raise RequestProccesingError(
+                f"{cls.__name__} empty ci_link "
+                f"in rerun request {rerun_request}"
+            )
         url = cls.extract_rerun_url_from_ci_link(ci_link)
         return PostArguments(url=url)
 

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -139,7 +139,7 @@ class JenkinsProcessor(RequestProcessor):
     # where Jenkins is deployed
     netloc = "10.102.156.15:8080"
     # what the path of Jenkins job run looks like
-    path_template = r"job/(?P<job_name>[\w-]+)/\d+"
+    path_template = r"job/(?P<job_name>[\w+-]+)/\d+"
 
     def __init__(self, user: str, password: str):
         auth = HTTPBasicAuth(user, password)

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -21,6 +21,16 @@ def test_jenkins_no_ci_link():
         JenkinsProcessor.process(rerun_request)
 
 
+def test_jenkins_empty_ci_link():
+    rerun_request = {
+        "test_execution_id": 1,
+        "family": "deb",
+        "ci_link": None
+    }
+    with pytest.raises(RequestProccesingError):
+        JenkinsProcessor.process(rerun_request)
+
+
 @pytest.mark.parametrize(
     "ci_link",
     [
@@ -64,6 +74,15 @@ def test_jenkins_invalid_family():
 def test_github_no_ci_link():
     rerun_request = {
         "test_execution_id": 1,
+    }
+    with pytest.raises(RequestProccesingError):
+        GithubProcessor.process(rerun_request)
+
+
+def test_github_empty_ci_link():
+    rerun_request = {
+        "test_execution_id": 1,
+        "ci_link": "",
     }
     with pytest.raises(RequestProccesingError):
         GithubProcessor.process(rerun_request)


### PR DESCRIPTION
## Description

Rerun requests for charms crashed the test execution rerunner because they contained `ci_link` entries with a `None` value. The existing tests for the rerunner covered the case where `ci_link` was missing but not the case where it was `None`. This PR addresses the issue.

Following the test process described below, it was also discovered that certain URLs contained an unexpected plus character (`+`) that resulted in the URLs not being matched by the regular expressions being used. This issue is also addressed.

## Tests

The offending rerun requests were retrieved from the logs and parsed locally, following the process in the README. The problem was reproduced and then resolved. The `test-executions-rerunner` Jenkins jobs was modified to retrieve the script from this branch and the rerun requests started going through.