### PR TITLE
[RTW-476] Make Github rerunner repo-sensitive

### DIFF
--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -154,7 +154,7 @@ class JenkinsProcessor(RequestProcessor):
             ) from error
         if not ci_link:
             raise RequestProccesingError(
-                f"{cls.__name__} empty ci_link "
+                f"{type(self).__name__} empty ci_link "
                 f"in rerun request {rerun_request}"
             )
         # extract the rerun URL from the ci_link

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -377,6 +377,10 @@ def create_rerunner_from_args():
         nargs="?", default="jenkins",
         help="Specify which request rerun processor to use"
     )
+    # only for Github processor but too simple to justify using subparsers
+    parser.add_argument(
+        "--repo", help="Name of Github repository"
+    )
     args = parser.parse_args()
 
     if args.processor == "jenkins":
@@ -385,7 +389,7 @@ def create_rerunner_from_args():
             environ["JENKINS_API_TOKEN"]
         )
     else:
-        processor = GithubProcessor(environ["GH_TOKEN"])
+        processor = GithubProcessor(environ["GH_TOKEN"], repo=args.repo)
     return Rerunner(processor)
 
 

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -101,9 +101,8 @@ class RequestProcessor(ABC):
         # (suitable e.g. for authorization)
         self.constant_post_arguments = constant_post_arguments
 
-    @classmethod
     @abstractmethod
-    def process(cls, rerun_request: dict) -> PostArguments:
+    def process(self, rerun_request: dict) -> PostArguments:
         """
         Return a dict containing POST arguments that will trigger a rerun,
         based on a Test Observer rerun request.
@@ -145,13 +144,12 @@ class JenkinsProcessor(RequestProcessor):
         auth = HTTPBasicAuth(user, password)
         super().__init__({"auth": auth})
 
-    @classmethod
-    def process(cls, rerun_request: dict) -> PostArguments:
+    def process(self, rerun_request: dict) -> PostArguments:
         try:
             ci_link = rerun_request["ci_link"]
         except KeyError as error:
             raise RequestProccesingError(
-                f"{cls.__name__} cannot find ci_link "
+                f"{type(self).__name__} cannot find ci_link "
                 f"in rerun request {rerun_request}"
             ) from error
         if not ci_link:
@@ -160,14 +158,14 @@ class JenkinsProcessor(RequestProcessor):
                 f"in rerun request {rerun_request}"
             )
         # extract the rerun URL from the ci_link
-        url = cls.extract_rerun_url_from_ci_link(ci_link)
+        url = self.extract_rerun_url_from_ci_link(ci_link)
         # determine additional payload arguments
         # based on the artifact family in the rerun request
         try:
             family = rerun_request["family"]
         except KeyError as error:
             raise RequestProccesingError(
-                f"{cls.__name__} cannot find family "
+                f"{type(self).__name__} cannot find family "
                 f"in rerun request {rerun_request}"
             ) from error
         if family == "deb":
@@ -181,7 +179,7 @@ class JenkinsProcessor(RequestProcessor):
             }
         else:
             raise RequestProccesingError(
-                f"{cls.__name__} cannot process family '{family}' "
+                f"{type(self).__name__} cannot process family '{family}' "
                 f"in rerun request {rerun_request}"
             )
         return PostArguments(url=url, json=json)
@@ -229,21 +227,20 @@ class GithubProcessor(RequestProcessor):
             }
         )
 
-    @classmethod
-    def process(cls, rerun_request: dict) -> PostArguments:
+    def process(self, rerun_request: dict) -> PostArguments:
         try:
             ci_link = rerun_request["ci_link"]
         except KeyError as error:
             raise RequestProccesingError(
-                f"{cls.__name__} cannot find ci_link "
+                f"{type(self).__name__} cannot find ci_link "
                 f"in rerun request {rerun_request}"
             ) from error
         if not ci_link:
             raise RequestProccesingError(
-                f"{cls.__name__} empty ci_link "
+                f"{type(self).__name__} empty ci_link "
                 f"in rerun request {rerun_request}"
             )
-        url = cls.extract_rerun_url_from_ci_link(ci_link)
+        url = self.extract_rerun_url_from_ci_link(ci_link)
         return PostArguments(url=url)
 
     @classmethod

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -9,6 +9,11 @@ from test_executions_rerunner import (
 )
 
 
+# processors for rerun requests, i.e. interfaces towards Jenkins and Github
+jenkins = JenkinsProcessor("admin", "jtoken")
+github = GithubProcessor("ghtoken")
+
+
 # collection of tests to check that the Jenkins and Github
 # request processors fail when they should
 
@@ -18,7 +23,7 @@ def test_jenkins_no_ci_link():
         "family": "deb"
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        jenkins.process(rerun_request)
 
 
 def test_jenkins_empty_ci_link():
@@ -28,7 +33,7 @@ def test_jenkins_empty_ci_link():
         "ci_link": None
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor.process(rerun_request)
+        jenkins.process(rerun_request)
 
 
 @pytest.mark.parametrize(
@@ -47,7 +52,7 @@ def test_jenkins_invalid_ci_link(ci_link):
         "family": "deb"
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        jenkins.process(rerun_request)
 
 
 def test_jenkins_no_family():
@@ -57,7 +62,7 @@ def test_jenkins_no_family():
         "ci_link": f"{job_link}/123",
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        jenkins.process(rerun_request)
 
 
 def test_jenkins_invalid_family():
@@ -68,7 +73,7 @@ def test_jenkins_invalid_family():
         "family": "image",
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        jenkins.process(rerun_request)
 
 
 def test_github_no_ci_link():
@@ -76,7 +81,7 @@ def test_github_no_ci_link():
         "test_execution_id": 1,
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        github.process(rerun_request)
 
 
 def test_github_empty_ci_link():
@@ -85,7 +90,7 @@ def test_github_empty_ci_link():
         "ci_link": "",
     }
     with pytest.raises(RequestProccesingError):
-        GithubProcessor.process(rerun_request)
+        github.process(rerun_request)
 
 
 @pytest.mark.parametrize(
@@ -103,7 +108,7 @@ def test_github_invalid_ci_link(ci_link):
         "ci_link": ci_link
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor(user="", password="").process(rerun_request)
+        github.process(rerun_request)
 
 
 # miscellaneous pieces of data to help with tests;
@@ -145,10 +150,6 @@ rerun_requests = [
         "ci_link": "https://github.com/canonical/fake-repo/actions/runs/39/job/117",
     },
 ]
-
-# processors for rerun requests, i.e. interfaces towards Jenkins and Github
-jenkins = JenkinsProcessor("admin", "jtoken")
-github = GithubProcessor("ghtoken")
 
 # the expected result of Rerunner.process_rerun_requests;
 # this allows one-to-one checking of how each rerun request is processed

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -18,7 +18,7 @@ def test_jenkins_no_ci_link():
         "family": "deb"
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 def test_jenkins_empty_ci_link():
@@ -47,7 +47,7 @@ def test_jenkins_invalid_ci_link(ci_link):
         "family": "deb"
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 def test_jenkins_no_family():
@@ -57,7 +57,7 @@ def test_jenkins_no_family():
         "ci_link": f"{job_link}/123",
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 def test_jenkins_invalid_family():
@@ -68,7 +68,7 @@ def test_jenkins_invalid_family():
         "family": "image",
     }
     with pytest.raises(RequestProccesingError):
-        JenkinsProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 def test_github_no_ci_link():
@@ -76,7 +76,7 @@ def test_github_no_ci_link():
         "test_execution_id": 1,
     }
     with pytest.raises(RequestProccesingError):
-        GithubProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 def test_github_empty_ci_link():
@@ -103,7 +103,7 @@ def test_github_invalid_ci_link(ci_link):
         "ci_link": ci_link
     }
     with pytest.raises(RequestProccesingError):
-        GithubProcessor.process(rerun_request)
+        JenkinsProcessor(user="", password="").process(rerun_request)
 
 
 # miscellaneous pieces of data to help with tests;


### PR DESCRIPTION
# Description

This PR allows rerun request processors for Github to restrict the requests they pick up to a specific repo. This is mostly a safety measure, to ensure that requests are not accidentally picked up by the wrong rerun request processor.

# Issues

Resolves [RTW-476](https://warthogs.atlassian.net/browse/RTW-476).

# Tests

- Extended local pytest tests
- Triggered a rerun through Test Observer and then manually triggered the `check-rerun-requests` workflow on a branch that uses this version of `test_rerun_requests.py`. The [log](https://github.com/canonical/certification-lab-ci/actions/runs/14593863488/job/40935019848#step:6:547) indicates the rerun request was picked up and serviced successfully (and [this](https://github.com/canonical/certification-lab-ci/actions/runs/14593110658) is the run that was tiggered twice).

[RTW-476]: https://warthogs.atlassian.net/browse/RTW-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ