### PR TITLE
mailtool: add Date field

### DIFF
--- a/mailtool
+++ b/mailtool
@@ -8,6 +8,7 @@ import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate
 
 SMTPSERVER = os.environ.get('SMTP_SERVER', 'localhost')
 SMTPUSER = os.environ.get('SMTP_USER', '')
@@ -66,6 +67,7 @@ def main():
     msg['Subject'] = args.subject
     msg['From'] = MAIL_FROM + '@canonical.com'
     msg['To'] = args.to
+    msg['Date'] = formatdate(localtime=True)
 
     s = smtplib.SMTP(SMTPSERVER)
     if SMTPUSER:

--- a/mailtool.py
+++ b/mailtool.py
@@ -8,6 +8,7 @@ import smtplib
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate
 
 SMTPSERVER = os.environ.get('SMTP_SERVER', 'localhost')
 
@@ -74,6 +75,7 @@ def send_mail(to=None, subject="(No Subject)", body=None, attachments=None):
     msg['Subject'] = subject
     msg['From'] = 'noreply@canonical.com'
     msg['To'] = to
+    msg['Date'] = formatdate(localtime=True)
 
     s = smtplib.SMTP(SMTPSERVER)
     s.send_message(msg)


### PR DESCRIPTION
Our mail servers don't always add the Date field, so instead force it when generating the email.