### PR TITLE
Force pipx to not install urwid 3.0.0+

### DIFF
--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -46,4 +46,5 @@ $TOOLS_PATH/version-published/checkout_to_version.py ~/checkbox "$VERSION"
 
 # install checkbox from source
 pipx install --spec checkbox/checkbox-ng checkbox-ng
+pipx inject checkbox-ng "urwid<3"
 sudo rm -rf checkbox


### PR DESCRIPTION
This force downgrades as a temporary workaroud to the broken version of urwid that was pushed recently 

See: https://github.com/urwid/urwid/issues/1017