### PR TITLE
fix: support `family` and `limit` query parameters

### DIFF
--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -41,13 +41,31 @@ class TestObserverInterface:
     retrieve or remove rerun requests.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        family: Optional[str] = None,
+        limit: Optional[int] = None
+    ):
         # at the moment there is a single Test Observer deployment but
         # the rerun endpoint could be a constructor argument in the future
         self.reruns_endpoint = (
             "https://test-observer-api.canonical.com/v1/"
             "test-executions/reruns"
         )
+        self.family = family
+        self.limit = limit
+
+    def create_get_params(self) -> Dict:
+        """
+        Return the query parameters for the GET request that
+        retrieves the rerun requests from Test Observer
+        """
+        params = {"family": self.family, "limit": self.limit}
+        return {
+            parameter: value
+            for parameter, value in params.items()
+            if value is not None
+        }
 
     def get(self) -> List[dict]:
         """
@@ -55,7 +73,9 @@ class TestObserverInterface:
 
         Raises an HTTPError if the operation fails.
         """
-        response = requests.get(self.reruns_endpoint)
+        response = requests.get(
+            self.reruns_endpoint, params=self.create_get_params()
+        )
         response.raise_for_status()
         return response.json()
 
@@ -282,8 +302,13 @@ class Rerunner:
     corresponding reruns.
     """
 
-    def __init__(self, processor: RequestProcessor):
-        self.test_observer = TestObserverInterface()
+    def __init__(
+        self,
+        processor: RequestProcessor,
+        family: Optional[str] = None,
+        limit: Optional[int] = None
+    ):
+        self.test_observer = TestObserverInterface(family=family, limit=limit)
         self.processor = processor
 
     def load_rerun_requests(self) -> List[Dict]:
@@ -376,6 +401,12 @@ def create_rerunner_from_args():
         "processor", choices=["jenkins", "github"],
         nargs="?", default="jenkins",
         help="Specify which request rerun processor to use"
+    )
+    parser.add_argument(
+        "--family", help="Restrict processing to a specific family of artifacts"
+    )
+    parser.add_argument(
+        "--limit", help="Restrict processing to a specific number of rerun requests"
     )
     # only for Github processor but too simple to justify using subparsers
     parser.add_argument(

--- a/scriptlets/test-executions-rerunner/test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_executions_rerunner.py
@@ -303,12 +303,9 @@ class Rerunner:
     """
 
     def __init__(
-        self,
-        processor: RequestProcessor,
-        family: Optional[str] = None,
-        limit: Optional[int] = None
+        self, interface: TestObserverInterface, processor: RequestProcessor
     ):
-        self.test_observer = TestObserverInterface(family=family, limit=limit)
+        self.test_observer = interface
         self.processor = processor
 
     def load_rerun_requests(self) -> List[Dict]:
@@ -421,7 +418,13 @@ def create_rerunner_from_args():
         )
     else:
         processor = GithubProcessor(environ["GH_TOKEN"], repo=args.repo)
-    return Rerunner(processor)
+
+    return Rerunner(
+        interface=TestObserverInterface(
+            family=args.family, limit=args.limit
+        ),
+        processor=processor
+    )
 
 
 if __name__ == "__main__":

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -10,6 +10,16 @@ from test_executions_rerunner import (
 )
 
 
+def test_test_observer_interface_params():
+    interface = TestObserverInterface()
+    assert interface.create_get_params() == {}
+    interface = TestObserverInterface(family="deb")
+    assert interface.create_get_params() == {"family": "deb"}
+    interface = TestObserverInterface(limit=100)
+    assert interface.create_get_params() == {"limit": 100}
+    interface = TestObserverInterface(family="snap", limit=1000)
+
+
 # processors for rerun requests, i.e. interfaces towards Jenkins and Github
 
 @fixture

--- a/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
+++ b/scriptlets/test-executions-rerunner/test_test_executions_rerunner.py
@@ -214,11 +214,11 @@ expected_processed_per_processor = {
 
 @pytest.fixture
 def rerunner_jenkins(jenkins):
-    return Rerunner(jenkins)
+    return Rerunner(TestObserverInterface(), jenkins)
 
 @pytest.fixture
 def rerunner_github(github_with_repo):
-    return Rerunner(github_with_repo)
+    return Rerunner(TestObserverInterface(), github_with_repo)
 
 
 def test_does_nothing_when_no_reruns_requested(rerunner_jenkins):


### PR DESCRIPTION
## Description

The current implementation of `TestObserverInteface` retrieves _all_ rerun requests and currently often times out because of the large amount of rerun requests for charms. Recently, the corresponding Test Observer endpoint introduced the `family` and `limit` query parameters in order to restrict the type and number of rerun requests returned.

This PR introduces support for these query parameters in `TestObserverInterface`, along with the corresponding command-line arguments.

## Tests

The PR includes appropriate unit tests for `TestObserverInterface`. In addition, the following manual tests were performed in the Python interactive shell.

```
>>> from test_executions_rerunner import TestObserverInterface
>>> interface = TestObserverInterface()
>>> interface.get()
```

This times out due to the size of the response.

```
>>> interface = TestObserverInterface(limit=10)
>>> interface.get()
```

This returns 10 rerun requests instantaneously.

```
>>> interface = TestObserverInterface(family="snap")
>>> interface.get()
```

This also returns the response instantaneously.

In addition, the command-line script was also invoked like this:
```
python3 test_executions_rerunner.py jenkins --limit 3 --family snap
```
Which resulted in a response containing three rerun requests that were appropriately processed.