### PR TITLE
Fix bug clone assumed to be in home

### DIFF
--- a/scriptlets/install_checkbox_agent_source
+++ b/scriptlets/install_checkbox_agent_source
@@ -38,6 +38,8 @@ elif [ -z "$TOOLS_PATH" ]; then
     exit 1
 fi
 
+set -e
+
 # clone Checkbox repo
 git clone --filter=tree:0 https://github.com/canonical/checkbox.git > /dev/null
 


### PR DESCRIPTION
The scriplet clones in cwd but assumes cwd is ~ in the next command. This is made additionally hard to find because the scriplet doesn't `set -e`, so checkbox appears to be installed to the correct revision, but it may fail further down the line.

We aren't observing this in our CI because the pre-supposition that we are in home currently holds there, but it may break in the future, so it is better to fix this right away

Minor: removed the rm -rf of the repo, only purpose it seems to have is to make debugging harder

## Tests:
Snap: http://10.102.156.15:8080/job/cert-shiner-imx8-med-pdk-core20-beta/28/console
Deb: http://10.102.156.15:8080/job/cert-stock-sru-jammy-desktop-precision-3551-c3x/140/console