### PR TITLE
new: rm snapd cache in clean_machine

### DIFF
--- a/scriptlets/clean_machine
+++ b/scriptlets/clean_machine
@@ -25,7 +25,7 @@ sudo dmesg -C
 sudo journalctl --rotate && sudo journalctl --vacuum-time=1s
 
 # clean-up snapd cache, to free up space before installing new snaps
-sudo rm -f /var/lib/snapd/cache
+sudo rm -f /var/lib/snapd/cache/*
 
 # delete all checkbox snaps, this includes any frontend or custom frontend
 # (they all contain checkbox in their name). This should also purge any


### PR DESCRIPTION
This solves issues like https://warthogs.atlassian.net/browse/TELOPS-2413 where low-memory machines fail at installing extra snaps because of high disk usage.

Test: http://10.102.156.15:8080/job/cert-havana-ptz-hon-hbt-cv22-kernel-latest-beta/41/console