### PR TITLE
new: allow to skip the checkbox controller installation

### DIFF
--- a/cert-tools/toolbox/src/toolbox/checkbox/installers/__init__.py
+++ b/cert-tools/toolbox/src/toolbox/checkbox/installers/__init__.py
@@ -85,14 +85,15 @@ class CheckboxInstaller(ABC):
         """Install Checkbox on the device."""
         raise NotImplementedError
 
-    def install(self, *args, skip_agent_install: bool = False, **kwargs):
+    def install(self, *args, skip_controller_install: bool = False, **kwargs):
         """Install Checkbox on both device and agent, ensuring versions match."""
         self.install_on_device(*args, **kwargs)
         self.check_service()
         version = self.get_version()
-        if skip_agent_install:
+        if skip_controller_install:
             logger.info(
-                "Skipping agent installation from source (--skip-agent-install)"
+                "Skipping controller installation from source"
+                " (--skip-controller-install)"
             )
         else:
             self.install_from_source_on_agent(version)

--- a/cert-tools/toolbox/src/toolbox/checkbox/installers/__init__.py
+++ b/cert-tools/toolbox/src/toolbox/checkbox/installers/__init__.py
@@ -85,9 +85,14 @@ class CheckboxInstaller(ABC):
         """Install Checkbox on the device."""
         raise NotImplementedError
 
-    def install(self, *args, **kwargs):
+    def install(self, *args, skip_agent_install: bool = False, **kwargs):
         """Install Checkbox on both device and agent, ensuring versions match."""
         self.install_on_device(*args, **kwargs)
         self.check_service()
         version = self.get_version()
-        self.install_from_source_on_agent(version)
+        if skip_agent_install:
+            logger.info(
+                "Skipping agent installation from source (--skip-agent-install)"
+            )
+        else:
+            self.install_from_source_on_agent(version)

--- a/cert-tools/toolbox/src/toolbox/cli/install_checkbox_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/install_checkbox_snaps.py
@@ -31,6 +31,11 @@ def main():
     parser.add_argument(
         "--blacklist", type=Path, help="Path to the connections blacklist"
     )
+    parser.add_argument(
+        "--skip-agent-install",
+        action="store_true",
+        help="Skip local installation of Checkbox from source on the agent",
+    )
     args = parser.parse_args()
 
     frontends = [SnapSpecifier.from_string(args.frontend)] + [
@@ -51,7 +56,7 @@ def main():
         snapstore=SnapstoreClient(create_base_client(TOKEN_ENVIRONMENT_VARIABLE)),
         predicates=[Blacklist.from_file(args.blacklist)] if args.blacklist else None,
     )
-    installer.install()
+    installer.install(skip_agent_install=args.skip_agent_install)
 
 
 if __name__ == "__main__":

--- a/cert-tools/toolbox/src/toolbox/cli/install_checkbox_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/install_checkbox_snaps.py
@@ -32,9 +32,9 @@ def main():
         "--blacklist", type=Path, help="Path to the connections blacklist"
     )
     parser.add_argument(
-        "--skip-agent-install",
+        "--skip-controller-install",
         action="store_true",
-        help="Skip local installation of Checkbox from source on the agent",
+        help="Skip local installation of Checkbox from source on the controller",
     )
     args = parser.parse_args()
 
@@ -56,7 +56,7 @@ def main():
         snapstore=SnapstoreClient(create_base_client(TOKEN_ENVIRONMENT_VARIABLE)),
         predicates=[Blacklist.from_file(args.blacklist)] if args.blacklist else None,
     )
-    installer.install(skip_agent_install=args.skip_agent_install)
+    installer.install(skip_controller_install=args.skip_controller_install)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using toolbox is pretty useful when dealing with a freshly provisioned device. 

When using the install-checkbox-* scripts, the agents gets a version of checkbox-cli using `pipx`. I'd like to avoid that when running the script from my machine, and just run checkbox from source. 

In practice, added `--skip-agent-install` to install on machine, and return.