### PR TITLE
fix: wait up to 10 minutes for checkbox to install

### DIFF
--- a/cert-tools/toolbox/src/toolbox/checkbox/installers/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/checkbox/installers/snaps.py
@@ -88,7 +88,7 @@ class CheckboxSnapsInstaller(CheckboxInstaller):
                 f"{snap.name}.snap",
                 snap.channel,
                 options=["--devmode"],
-                policy=Linear(times=30, delay=10),
+                policy=Linear(times=60, delay=10),
             )
             strict = True
         except SnapInstallError:
@@ -101,7 +101,7 @@ class CheckboxSnapsInstaller(CheckboxInstaller):
                 f"{snap.name}.snap",
                 snap.channel,
                 options=["--classic"],
-                policy=Linear(times=30, delay=10),
+                policy=Linear(times=60, delay=10),
             )
             strict = False
         return strict


### PR DESCRIPTION
There are checkbox frontends which are a bit heavy on dependencies, and the lab network is not doing great recently. 

We noticed `checkbox-mir` takes around 6 minutes to install, while we wait only up to 5.

Also, we fallback to `--classic` installation, which makes sense only when the exception is not raised because of a timeout, but only by snapd.

Tested on http://10.102.156.15:8080/job/cert-mir-jammy-ubuntu-frame-24-beta-intel-amd64/244/console