### PR TITLE
Thrown SnapdApi Exception on failed parsing instead of crashing

### DIFF
--- a/cert-tools/toolbox/src/toolbox/interfaces/snapd.py
+++ b/cert-tools/toolbox/src/toolbox/interfaces/snapd.py
@@ -129,7 +129,14 @@ class SnapdAPIClient(DeviceInterface):
         )
         if not response.stdout:
             raise SnapdAPIError(response.stderr if response.stderr else "No response")
-        header, body = self.parse(response.stdout)
+        try:
+            header, body = self.parse(response.stdout)
+        except ValueError as e:
+            # If an invalid chunk is returned, the function will throw
+            raise SnapdAPIError(
+                f"Invalid reponse header or body. Failed to parse: {response.stdout}"
+                f"\nParsing failed with error: {e}"
+            )
         status = header["status"]
         if status["status-code"] != "200":
             try:


### PR DESCRIPTION
# Description
parse may crash the whole with a value error if an invalid chunked stream is returned. This should be avoided in its current form as the caller doesn't expect a ValueError. Change the exception to the proper class and explain with a better error

# Error
Reported in MM
```
Traceback (most recent call last):
    File "/home/ubuntu/.local/bin/wait-for-snap-changes", line 6, in <module>
      sys.exit(main())
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/cli/wait_for_snap_changes.py", line 26, in main
      result = device.interfaces[SnapInterface].wait_for_snap_changes(
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snaps.py", line 100, in wait_for_snap_changes
      return retry(check_snap_changes, policy=policy)
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/retries.py", line 56, in retry
      result = script()
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snaps.py", line 75, in check_snap_changes_complete_and_reboot
      complete = self.check_snap_changes_complete()
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snaps.py", line 55, in check_snap_changes_complete
      changes = self.get_changes()
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snaps.py", line 44, in get_changes
      return self.device.interfaces[SnapdAPIClient].get(
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snapd.py", line 132, in get
      header, body = self.parse(response.stdout)
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snapd.py", line 84, in parse
      body = cls.parse_chunked_body(raw_body)
    File "/home/ubuntu/.local/pipx/venvs/toolbox/lib/python3.10/site-packages/toolbox/interfaces/snapd.py", line 74, in parse_chunked_body
      chunk_size_hex, raw_body = re.split(r"\n|\r\n", raw_body, maxsplit=1)
  ValueError: not enough values to unpack (expected 2, got 1)
```