### PR TITLE
Ensure stable snaps

### DIFF
--- a/cert-tools/toolbox/README.md
+++ b/cert-tools/toolbox/README.md
@@ -219,6 +219,7 @@ wait-for-packages-complete = "toolbox.cli.wait_for_packages_complete:main"
 wait-for-snap-changes = "toolbox.cli.wait_for_snap_changes:main"
 install-checkbox-snaps = "toolbox.cli.install_checkbox_snaps:main"
 install-checkbox-debs = "toolbox.cli.install_checkbox_debs:main"
+ensure-stable-snaps = "toolbox.cli.ensure_stable_snaps:main"
 ensure-kernel = "toolbox.cli.ensure_kernel:main"
 ```
 

--- a/cert-tools/toolbox/pyproject.toml
+++ b/cert-tools/toolbox/pyproject.toml
@@ -26,6 +26,7 @@ wait-for-snap-changes = "toolbox.cli.wait_for_snap_changes:main"
 install-checkbox-snaps = "toolbox.cli.install_checkbox_snaps:main"
 install-checkbox-debs = "toolbox.cli.install_checkbox_debs:main"
 ensure-kernel = "toolbox.cli.ensure_kernel:main"
+ensure-stable-snaps = "toolbox.cli.ensure_stable_snaps:main"
 # deprecated, used by the bash version of install_checkbox_snaps
 snap_connections = "toolbox.snap_connections:main"
 

--- a/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
@@ -1,0 +1,61 @@
+from contextlib import suppress
+
+from toolbox.devices.lab import LabDevice
+from toolbox.interfaces.reboot import RebootInterface
+from toolbox.interfaces.snapd import SnapdAPIClient
+from toolbox.interfaces.snaps import SnapInstallError, SnapInterface
+from toolbox.interfaces.status import SystemStatusInterface
+from toolbox.retries import Linear
+
+MAX_RETRY = 3
+
+
+def main():
+    ld = LabDevice(
+        interfaces=[
+            SystemStatusInterface(),
+            RebootInterface(),
+            SnapdAPIClient(),
+            SnapInterface(),
+        ]
+    )
+    print("Refreshing all installed snaps to stable")
+    installed_snaps = ld.interfaces[SnapInterface].list()
+    refresh_failed = []
+    for snap in installed_snaps:
+        snap.risk = "stable"
+        # ingore refresh errors as there may be dependencies between refreshes
+        # that aren't trivial to fix right away, for now refresh as much as we
+        # can
+        try:
+            print(f"Refreshing '{snap.name}' to '{snap.channel}'")
+            ld.interfaces[SnapInterface].install(
+                snap.name,
+                snap.channel,
+                refresh_ok=True,
+                policy=Linear(times=3, delay=60),
+            )
+        except SnapInstallError:
+            refresh_failed.append(snap)
+            print(f"Snap '{snap.name}' failed to refresh, retrying at the end")
+
+    retry = MAX_RETRY
+    while refresh_failed and retry > 0:
+        to_refresh = refresh_failed.pop(0)
+        print("Retrying to refresh snap: {to_refresh.name}")
+        try:
+            ld.interfaces[SnapInterface].install(
+                to_refresh.name,
+                to_refresh.channel,
+                refresh_ok=True,
+                policy=Linear(times=3, delay=600),
+            )
+            retry = MAX_RETRY
+        except SnapInstallError:
+            print("Failed to refresh snap: {to_refresh.name}")
+            refresh_failed.append(snap)
+            retry -= 1
+
+
+if __name__ == "__main__":
+    main()

--- a/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
@@ -32,7 +32,7 @@ def main():
     installed_snaps = ld.interfaces[SnapInterface].get_list()
     refresh_failed = []
     for snap in installed_snaps:
-        snap.risk = "stable"
+        snap.channel.risk = "stable"
         # ingore refresh errors as there may be dependencies between refreshes
         # that aren't trivial to fix right away, for now refresh as much as we
         # can
@@ -40,7 +40,7 @@ def main():
             print(f"Refreshing '{snap.name}' to '{snap.channel}'")
             ld.interfaces[SnapInterface].install(
                 snap.name,
-                snap.channel,
+                str(snap.channel),
                 refresh_ok=True,
                 policy=Linear(times=3, delay=60),
             )
@@ -55,7 +55,7 @@ def main():
         try:
             ld.interfaces[SnapInterface].install(
                 to_refresh.name,
-                to_refresh.channel,
+                str(to_refresh.channel),
                 refresh_ok=True,
                 policy=Linear(times=3, delay=600),
             )

--- a/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
@@ -1,4 +1,4 @@
-from contextlib import suppress
+from argparse import ArgumentParser
 
 from toolbox.devices.lab import LabDevice
 from toolbox.interfaces.reboot import RebootInterface
@@ -11,6 +11,15 @@ MAX_RETRY = 3
 
 
 def main():
+    parser = ArgumentParser(
+        description="Refresh all installed snaps on a lab device to stable.",
+        epilog=(
+            "This script uses the DEVICE_IP and DEVICE_USER environment "
+            "variables to connect to the lab device."
+        ),
+    )
+    parser.parse_args()
+
     ld = LabDevice(
         interfaces=[
             SystemStatusInterface(),
@@ -39,10 +48,10 @@ def main():
             refresh_failed.append(snap)
             print(f"Snap '{snap.name}' failed to refresh, retrying at the end")
 
-    retry = MAX_RETRY
-    while refresh_failed and retry > 0:
+    retries = {snap.name: MAX_RETRY for snap in refresh_failed}
+    while refresh_failed:
         to_refresh = refresh_failed.pop(0)
-        print("Retrying to refresh snap: {to_refresh.name}")
+        print(f"Retrying to refresh snap: {to_refresh.name}")
         try:
             ld.interfaces[SnapInterface].install(
                 to_refresh.name,
@@ -50,11 +59,17 @@ def main():
                 refresh_ok=True,
                 policy=Linear(times=3, delay=600),
             )
-            retry = MAX_RETRY
         except SnapInstallError:
-            print("Failed to refresh snap: {to_refresh.name}")
-            refresh_failed.append(snap)
-            retry -= 1
+            print(f"Failed to refresh snap: {to_refresh.name}")
+            refresh_failed.append(to_refresh)
+            retries[to_refresh.name] -= 1
+            if retries[to_refresh.name] == 0:
+                break
+    if refresh_failed:
+        raise SystemExit(
+            "Failed to refresh to stable the following snaps:\n-"
+            + "\n-".join(snap.name for snap in refresh_failed)
+        )
 
 
 if __name__ == "__main__":

--- a/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
+++ b/cert-tools/toolbox/src/toolbox/cli/ensure_stable_snaps.py
@@ -29,7 +29,7 @@ def main():
         ]
     )
     print("Refreshing all installed snaps to stable")
-    installed_snaps = ld.interfaces[SnapInterface].list()
+    installed_snaps = ld.interfaces[SnapInterface].get_list()
     refresh_failed = []
     for snap in installed_snaps:
         snap.risk = "stable"

--- a/cert-tools/toolbox/src/toolbox/entities/channels.py
+++ b/cert-tools/toolbox/src/toolbox/entities/channels.py
@@ -20,7 +20,7 @@ class Channel:
     def from_string(cls, channel: str) -> "Channel":
         # template for matching snap channels in the form track/risk/branch
         # (only one of track or risk is required)
-        channel_template = r"^(?:([\w.-]+)(?:/([\w-]+)(?:/([\w-]+))?)?)?$"
+        channel_template = r"^(?:([\w.-]+)(?:/([\w-]+)(?:/([\w\-\.]+))?)?)?$"
         match = re.match(channel_template, channel)
         if not match:
             raise ValueError(f"Cannot parse '{channel}' as a snap channel")

--- a/cert-tools/toolbox/src/toolbox/entities/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/entities/snaps.py
@@ -23,5 +23,11 @@ class SnapSpecifier(NamedTuple):
             ) from error
         return cls(name=name, channel=channel)
 
+    @classmethod
+    def from_snapd_snaps(cls, snap_response: dict) -> "SnapSpecifier":
+        name = snap_response["name"]
+        channel = Channel.from_string(snap_response["tracking-channel"])
+        return cls(name=name, channel=channel)
+
     def __str__(self) -> str:
         return f"{self.name}={self.channel}"

--- a/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
@@ -10,7 +10,6 @@ from toolbox.interfaces.status import SystemStatusInterface
 from toolbox.results import BooleanResult
 from toolbox.retries import retry, RetryPolicy
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -26,11 +25,41 @@ class SnapNotFoundError(SnapInstallError):
     pass
 
 
+class SnapSpec:
+    def __init__(self, name, risk, track, branch):
+        self.name = name
+        self.risk = risk
+        self.track = track
+        self.branch = branch
+
+    @classmethod
+    def from_snapd_snaps(cls, snap_response: dict):
+        name = snap_response["name"]
+        tracking_channel = snap_response["tracking-channel"]
+        track, risk, *branch = tracking_channel.split("/", maxsplit=3)
+        branch = branch[0] if branch else None
+        return cls(name, risk=risk, track=track, branch=branch)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} ({self.name} {self.channel})>"
+
+    @property
+    def channel(self):
+        branch_repr = "/" + self.branch if self.branch else ""
+        return f"{self.track}/{self.risk}{branch_repr}"
+
+
 class SnapInterface(
     DeviceInterface,
     requires=(RebootInterface, SnapdAPIClient, SystemStatusInterface),
 ):
     """Provides snap package management capabilities."""
+
+    def list(self) -> list:
+        return [
+            SnapSpec.from_snapd_snaps(snap)
+            for snap in self.device.interfaces[SnapdAPIClient].get("snaps")
+        ]
 
     def get_active(self, snap: str | None = None) -> dict:
         """Get active snap(s) from the device."""
@@ -47,7 +76,9 @@ class SnapInterface(
 
     def get_change(self, id: str) -> dict:
         """Get a specific snap change by ID."""
-        return self.device.interfaces[SnapdAPIClient].get(endpoint=f"changes/{id}")
+        return self.device.interfaces[SnapdAPIClient].get(
+            endpoint=f"changes/{id}"
+        )
 
     def check_snap_changes_complete(self) -> BooleanResult:
         """Check if all snap changes are in a "ready" state."""
@@ -62,10 +93,13 @@ class SnapInterface(
         logger.info("Snap operations are ongoing")
         ongoing_changes = [change for change in changes if not change["ready"]]
         for change in ongoing_changes:
-            logger.info(f"{change['id']} {change['status']}: {change['summary']}")
+            logger.info(
+                f"{change['id']} {change['status']}: {change['summary']}"
+            )
         return BooleanResult(
             False,
-            "Changes: " + ", ".join(sorted(change["id"] for change in ongoing_changes)),
+            "Changes: "
+            + ", ".join(sorted(change["id"] for change in ongoing_changes)),
         )
 
     def check_snap_changes_complete_and_reboot(
@@ -77,7 +111,9 @@ class SnapInterface(
             not complete
             and self.device.interfaces[RebootInterface].is_reboot_required()
         ):
-            logger.info("Manually rebooting to complete waiting snap changes...")
+            logger.info(
+                "Manually rebooting to complete waiting snap changes..."
+            )
             self.device.interfaces[RebootInterface].reboot()
             self.device.interfaces[SystemStatusInterface].wait_for_status(
                 allowed={"degraded"}, policy=status_policy
@@ -92,7 +128,8 @@ class SnapInterface(
     ) -> BooleanResult:
         """Wait for snap changes to complete, retrying with the given policy."""
         check_snap_changes = partial(
-            self.check_snap_changes_complete_and_reboot, status_policy=status_policy
+            self.check_snap_changes_complete_and_reboot,
+            status_policy=status_policy,
         )
         check_snap_changes.__name__ = (
             self.check_snap_changes_complete_and_reboot.__name__
@@ -115,7 +152,9 @@ class SnapInterface(
         an auto-refresh in the background may cause the device to reboot,
         and this approach protects against that.
         """
-        action = "refresh" if self.get_active(snap) and refresh_ok else "install"
+        action = (
+            "refresh" if self.get_active(snap) and refresh_ok else "install"
+        )
         command = ["sudo", "snap", action, "--no-wait", snap]
         if channel:
             command.append(f"--channel={channel}")
@@ -128,7 +167,9 @@ class SnapInterface(
                 if "not found" in install_result.stderr
                 else SnapInstallError
             )
-            raise error_cls(f"Failed to run '{command}': {install_result.stderr}")
+            raise error_cls(
+                f"Failed to run '{command}': {install_result.stderr}"
+            )
         snap_change_id = install_result.stdout.strip()
         if not snap_change_id:
             return

--- a/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
@@ -55,7 +55,7 @@ class SnapInterface(
 ):
     """Provides snap package management capabilities."""
 
-    def list(self) -> list:
+    def get_list(self) -> list[SnapSpec]:
         return [
             SnapSpec.from_snapd_snaps(snap)
             for snap in self.device.interfaces[SnapdAPIClient].get("snaps")

--- a/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
@@ -3,6 +3,7 @@
 from functools import partial
 import logging
 
+from toolbox.entities.snaps import SnapSpecifier
 from toolbox.interfaces import DeviceInterface
 from toolbox.interfaces.reboot import RebootInterface
 from toolbox.interfaces.snapd import SnapdAPIClient, SnapdAPIError
@@ -25,39 +26,15 @@ class SnapNotFoundError(SnapInstallError):
     pass
 
 
-class SnapSpec:
-    def __init__(self, name, risk, track, branch):
-        self.name = name
-        self.risk = risk
-        self.track = track
-        self.branch = branch
-
-    @classmethod
-    def from_snapd_snaps(cls, snap_response: dict):
-        name = snap_response["name"]
-        tracking_channel = snap_response["tracking-channel"]
-        track, risk, *branch = tracking_channel.split("/", maxsplit=3)
-        branch = branch[0] if branch else None
-        return cls(name, risk=risk, track=track, branch=branch)
-
-    def __repr__(self):
-        return f"<{self.__class__.__name__} ({self.name} {self.channel})>"
-
-    @property
-    def channel(self):
-        branch_repr = "/" + self.branch if self.branch else ""
-        return f"{self.track}/{self.risk}{branch_repr}"
-
-
 class SnapInterface(
     DeviceInterface,
     requires=(RebootInterface, SnapdAPIClient, SystemStatusInterface),
 ):
     """Provides snap package management capabilities."""
 
-    def get_list(self) -> list[SnapSpec]:
+    def get_list(self) -> list[SnapSpecifier]:
         return [
-            SnapSpec.from_snapd_snaps(snap)
+            SnapSpecifier.from_snapd_snaps(snap)
             for snap in self.device.interfaces[SnapdAPIClient].get("snaps")
         ]
 

--- a/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
+++ b/cert-tools/toolbox/src/toolbox/interfaces/snaps.py
@@ -76,9 +76,7 @@ class SnapInterface(
 
     def get_change(self, id: str) -> dict:
         """Get a specific snap change by ID."""
-        return self.device.interfaces[SnapdAPIClient].get(
-            endpoint=f"changes/{id}"
-        )
+        return self.device.interfaces[SnapdAPIClient].get(endpoint=f"changes/{id}")
 
     def check_snap_changes_complete(self) -> BooleanResult:
         """Check if all snap changes are in a "ready" state."""
@@ -93,13 +91,10 @@ class SnapInterface(
         logger.info("Snap operations are ongoing")
         ongoing_changes = [change for change in changes if not change["ready"]]
         for change in ongoing_changes:
-            logger.info(
-                f"{change['id']} {change['status']}: {change['summary']}"
-            )
+            logger.info(f"{change['id']} {change['status']}: {change['summary']}")
         return BooleanResult(
             False,
-            "Changes: "
-            + ", ".join(sorted(change["id"] for change in ongoing_changes)),
+            "Changes: " + ", ".join(sorted(change["id"] for change in ongoing_changes)),
         )
 
     def check_snap_changes_complete_and_reboot(
@@ -111,9 +106,7 @@ class SnapInterface(
             not complete
             and self.device.interfaces[RebootInterface].is_reboot_required()
         ):
-            logger.info(
-                "Manually rebooting to complete waiting snap changes..."
-            )
+            logger.info("Manually rebooting to complete waiting snap changes...")
             self.device.interfaces[RebootInterface].reboot()
             self.device.interfaces[SystemStatusInterface].wait_for_status(
                 allowed={"degraded"}, policy=status_policy
@@ -152,9 +145,7 @@ class SnapInterface(
         an auto-refresh in the background may cause the device to reboot,
         and this approach protects against that.
         """
-        action = (
-            "refresh" if self.get_active(snap) and refresh_ok else "install"
-        )
+        action = "refresh" if self.get_active(snap) and refresh_ok else "install"
         command = ["sudo", "snap", action, "--no-wait", snap]
         if channel:
             command.append(f"--channel={channel}")
@@ -167,9 +158,7 @@ class SnapInterface(
                 if "not found" in install_result.stderr
                 else SnapInstallError
             )
-            raise error_cls(
-                f"Failed to run '{command}': {install_result.stderr}"
-            )
+            raise error_cls(f"Failed to run '{command}': {install_result.stderr}")
         snap_change_id = install_result.stdout.strip()
         if not snap_change_id:
             return

--- a/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
+++ b/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
@@ -4,7 +4,9 @@ from collections import Counter
 import pytest
 
 from toolbox.cli import ensure_stable_snaps
-from toolbox.interfaces.snaps import SnapInstallError, SnapSpec
+from toolbox.entities.channels import Channel
+from toolbox.entities.snaps import SnapSpecifier
+from toolbox.interfaces.snaps import SnapInstallError
 
 
 @pytest.fixture
@@ -21,9 +23,12 @@ class TestEnsureStableSnaps:
     def test_all_snaps_refresh_first_try(self, snap_interface):
         """All snaps refresh on the first attempt, so main() exits cleanly."""
         snaps = [
-            SnapSpec("checkbox22", "latest", "beta", None),
-            SnapSpec("core", "latest", "stable", None),
-            SnapSpec("core22", "latest", "stable", "security_branch_123"),
+            SnapSpecifier("checkbox22", Channel(track="latest", risk="beta")),
+            SnapSpecifier("core", Channel(track="latest", risk="stable")),
+            SnapSpecifier(
+                "core22",
+                Channel(track="latest", risk="stable", branch="security_branch_123"),
+            ),
         ]
         snap_interface.get_list.return_value = snaps
 
@@ -31,14 +36,14 @@ class TestEnsureStableSnaps:
 
         assert snap_interface.install.call_count == len(snaps)
         for snap in snaps:
-            assert snap.risk == "stable"
+            assert snap.channel.risk == "stable"
 
     def test_two_snaps_refresh_on_retry(self, snap_interface):
         """Two snaps fail on the first try but succeed when retried."""
         snaps = [
-            SnapSpec("checkbox22", "latest", "stable", None),
-            SnapSpec("core", "latest", "stable", None),
-            SnapSpec("core22", "latest", "stable", None),
+            SnapSpecifier("checkbox22", Channel(track="latest", risk="stable")),
+            SnapSpecifier("core", Channel(track="latest", risk="stable")),
+            SnapSpecifier("core22", Channel(track="latest", risk="stable")),
         ]
         snap_interface.get_list.return_value = snaps
         failing_first = {"checkbox22", "core22"}
@@ -58,8 +63,8 @@ class TestEnsureStableSnaps:
     def test_one_snap_never_refreshes_raises_systemexit(self, snap_interface):
         """A snap that never refreshes exhausts retries and raises SystemExit."""
         snaps = [
-            SnapSpec("checkbox22", "latest", "stable", None),
-            SnapSpec("core", "latest", "stable", None),
+            SnapSpecifier("checkbox22", Channel(track="latest", risk="stable")),
+            SnapSpecifier("core", Channel(track="latest", risk="stable")),
         ]
         snap_interface.get_list.return_value = snaps
         attempts = Counter()

--- a/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
+++ b/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
@@ -1,0 +1,78 @@
+import sys
+from collections import Counter
+
+import pytest
+
+from toolbox.cli import ensure_stable_snaps
+from toolbox.interfaces.snaps import SnapInstallError, SnapSpec
+
+
+@pytest.fixture
+def snap_interface(mocker):
+    mocker.patch.object(sys, "argv", ["ensure-stable-snaps"])
+    mock_lab = mocker.patch.object(ensure_stable_snaps, "LabDevice")
+    interface = mock_lab.return_value.interfaces.__getitem__.return_value
+    return interface
+
+
+class TestEnsureStableSnaps:
+    """Tests for the ensure_stable_snaps.main() entry point."""
+
+    def test_all_snaps_refresh_first_try(self, snap_interface):
+        """All snaps refresh on the first attempt, so main() exits cleanly."""
+        snaps = [
+            SnapSpec("checkbox22", "latest", "beta", None),
+            SnapSpec("core", "latest", "stable", None),
+            SnapSpec("core22", "latest", "stable", None),
+        ]
+        snap_interface.list.return_value = snaps
+
+        ensure_stable_snaps.main()
+
+        assert snap_interface.install.call_count == len(snaps)
+        for snap in snaps:
+            assert snap.risk == "stable"
+
+    def test_two_snaps_refresh_on_retry(self, snap_interface):
+        """Two snaps fail on the first try but succeed when retried."""
+        snaps = [
+            SnapSpec("checkbox22", "latest", "stable", None),
+            SnapSpec("core", "latest", "stable", None),
+            SnapSpec("core22", "latest", "stable", None),
+        ]
+        snap_interface.list.return_value = snaps
+        failing_first = {"checkbox22", "core22"}
+        attempts = Counter()
+
+        def install(name, channel, **kwargs):
+            attempts[name] += 1
+            if name in failing_first and attempts[name] == 1:
+                raise SnapInstallError(f"{name} failed to refresh")
+
+        snap_interface.install.side_effect = install
+
+        ensure_stable_snaps.main()
+
+        assert attempts == Counter({"checkbox22": 2, "core22": 2, "core": 1})
+
+    def test_one_snap_never_refreshes_raises_systemexit(self, snap_interface):
+        """A snap that never refreshes exhausts retries and raises SystemExit."""
+        snaps = [
+            SnapSpec("checkbox22", "latest", "stable", None),
+            SnapSpec("core", "latest", "stable", None),
+        ]
+        snap_interface.list.return_value = snaps
+        attempts = Counter()
+
+        def install(name, channel, **kwargs):
+            attempts[name] += 1
+            if name == "checkbox22":
+                raise SnapInstallError("checkbox22 failed to refresh")
+
+        snap_interface.install.side_effect = install
+
+        with pytest.raises(SystemExit) as exc_info:
+            ensure_stable_snaps.main()
+
+        assert "checkbox22" in str(exc_info.value)
+        assert attempts["checkbox22"] == ensure_stable_snaps.MAX_RETRY + 1

--- a/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
+++ b/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
@@ -23,7 +23,7 @@ class TestEnsureStableSnaps:
         snaps = [
             SnapSpec("checkbox22", "latest", "beta", None),
             SnapSpec("core", "latest", "stable", None),
-            SnapSpec("core22", "latest", "stable", None),
+            SnapSpec("core22", "latest", "stable", "security_branch_123"),
         ]
         snap_interface.get_list.return_value = snaps
 

--- a/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
+++ b/cert-tools/toolbox/tests/cli/test_ensure_stable_snaps.py
@@ -25,7 +25,7 @@ class TestEnsureStableSnaps:
             SnapSpec("core", "latest", "stable", None),
             SnapSpec("core22", "latest", "stable", None),
         ]
-        snap_interface.list.return_value = snaps
+        snap_interface.get_list.return_value = snaps
 
         ensure_stable_snaps.main()
 
@@ -40,7 +40,7 @@ class TestEnsureStableSnaps:
             SnapSpec("core", "latest", "stable", None),
             SnapSpec("core22", "latest", "stable", None),
         ]
-        snap_interface.list.return_value = snaps
+        snap_interface.get_list.return_value = snaps
         failing_first = {"checkbox22", "core22"}
         attempts = Counter()
 
@@ -61,7 +61,7 @@ class TestEnsureStableSnaps:
             SnapSpec("checkbox22", "latest", "stable", None),
             SnapSpec("core", "latest", "stable", None),
         ]
-        snap_interface.list.return_value = snaps
+        snap_interface.get_list.return_value = snaps
         attempts = Counter()
 
         def install(name, channel, **kwargs):

--- a/cert-tools/toolbox/tests/entities/test_snaps.py
+++ b/cert-tools/toolbox/tests/entities/test_snaps.py
@@ -75,6 +75,27 @@ class TestSnapSpecifierFromString:
             SnapSpecifier.from_string(invalid_string)
 
 
+class TestSnapSpecifierFromSnapdSnaps:
+    """Tests for SnapSpecifier.from_snapd_snaps() method."""
+
+    @pytest.mark.parametrize(
+        "tracking_channel,expected_channel_str",
+        [
+            ("latest/stable", "latest/stable"),
+            ("22/candidate", "22/candidate"),
+            ("latest/stable/hotfix", "latest/stable/hotfix"),
+            ("stable", "stable"),
+        ],
+    )
+    def test_from_snapd_snaps(self, tracking_channel, expected_channel_str):
+        """Test building a snap specifier from a snapd snap response."""
+        snap = SnapSpecifier.from_snapd_snaps(
+            {"name": "checkbox", "tracking-channel": tracking_channel}
+        )
+        assert snap.name == "checkbox"
+        assert str(snap.channel) == expected_channel_str
+
+
 class TestSnapSpecifierStringRepresentation:
     """Tests for SnapSpecifier.__str__() method."""
 


### PR DESCRIPTION
# Description

This scriplet ensures that all snaps that are pre-installed in the image are refreshed to the latest available stable revision in the stable channel they are tracking. 

For example, snapd latest/stable will be refreshed to latest/stable (simulating an instant autorefresh to the tracked channel), while bluez 22/stable will be refreshed to 22/stable.

This also "downgrades" to stable any snap that is not stable (without changing the track as well), this cleans up the setup from any previous manual modification that may have been made.

# Testing
```
lxc launch ubuntu:resolute resolute
# set your DEVICE_IP/DEVICE_USER using lxc ls
lxc exec resolute -- snap install hello-world
lxc exec resolute -- snap install checkbox --channel=24.04/beta
ensure-stable-snaps
```
