### PR TITLE
fix: Compare the kernel versions ignoring patch version of the metapackage

### DIFF
--- a/cert-tools/toolbox/src/toolbox/cli/ensure_kernel.py
+++ b/cert-tools/toolbox/src/toolbox/cli/ensure_kernel.py
@@ -30,13 +30,12 @@ def parse_booted_version(version_signature: str) -> str:
     return fields[1]
 
 
-def booted_expected_kernel(booted_version_flavour: str, expected_version: str) -> bool:
-    """Return True if the booted kernel matches the expected version.
-
-    ``expected_version`` (e.g. ``6.8.0-130.130``) does not include the flavour,
-    so the booted version+flavour must start with ``<expected_version>-``.
+def normalize_version(version: str) -> str:
     """
-    return booted_version_flavour.startswith(f"{expected_version}-")
+    Normalize both versions so that they are comparable
+    """
+    version = version.replace("-", ".").replace("_", ".")
+    return ".".join(version.split(".")[:4])
 
 
 def main():
@@ -59,27 +58,28 @@ def main():
         sys.exit(1)
 
     version_signature = result.stdout.strip()
-    booted_version_flavour = parse_booted_version(version_signature)
+    booted_version_flavour = normalize_version(parse_booted_version(version_signature))
+    expected_version = normalize_version(args.expected_version)
     print("Kernel verification (active kernel):")
-    print(f"  version_signature : {version_signature}")
-    print(f"  booted version    : {booted_version_flavour}")
-    print(f"  expected version  : {args.expected_version}")
+    print(f"  version_signature             : {version_signature}")
+    print(f"  booted version   (normalized) : {booted_version_flavour}")
+    print(f"  expected version (normalized) : {expected_version}")
     if not booted_version_flavour:
         print(
             "ERROR: could not determine the booted kernel version from "
             f"{VERSION_SIGNATURE_PATH}"
         )
         sys.exit(1)
-    if not booted_expected_kernel(booted_version_flavour, args.expected_version):
+    if booted_version_flavour != expected_version:
         print(
-            f"ERROR: booted kernel version {booted_version_flavour} does not "
-            f"match the expected version {args.expected_version}; the device "
+            f"ERROR: booted kernel version ({booted_version_flavour}) does not "
+            f"match the expected version ({expected_version}); the device "
             "did not boot the expected kernel"
         )
         sys.exit(1)
     print(
         "Kernel verification OK: device booted expected kernel "
-        f"{args.expected_version} ({booted_version_flavour})"
+        f"{expected_version} ({booted_version_flavour})"
     )
 
 

--- a/cert-tools/toolbox/tests/cli/test_ensure_kernel.py
+++ b/cert-tools/toolbox/tests/cli/test_ensure_kernel.py
@@ -5,7 +5,7 @@ from invoke import Result
 
 from toolbox.cli import ensure_kernel
 from toolbox.cli.ensure_kernel import (
-    booted_expected_kernel,
+    normalize_version,
     main,
     parse_booted_version,
 )
@@ -28,13 +28,14 @@ def test_parse_booted_version(signature, expected):
     [
         ("6.8.0-130.130-generic", "6.8.0-130.130", True),
         ("6.8.0-131.131-generic", "6.8.0-130.130", False),
-        # "6.8.0-130.13" must not match "6.8.0-130.130-generic": the trailing
-        # dash in the expected prefix guards against partial-number matches.
-        ("6.8.0-130.130-generic", "6.8.0-130.13", False),
+        # regression: metapackage may have 5 . separated digits, fith one doesn't matter
+        ("5.15.0-186.196-generic", "5.15.0.186.166", True),
     ],
 )
 def test_booted_expected_kernel(booted_version_flavour, expected_version, expected):
-    assert booted_expected_kernel(booted_version_flavour, expected_version) is expected
+    assert (
+        normalize_version(booted_version_flavour) == normalize_version(expected_version)
+    ) == expected
 
 
 def _patch_device(mocker, result):


### PR DESCRIPTION
The kernel metapackage may have a different patch version than the actual kernel. We should indeed ignore any version number after the 4th. 

Additionally the kernel package may use a `-` to separate the last digit, we have to be robust to that as well 