### PR TITLE
[OEIOT-938] README: add retry and fast-fail flags to curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Certification tasks that need to make use of the tools in this repo can use the 
 
 ```bash
 export TOOLS_PATH=tools
-curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/certification-lab-ci-tools/refs/heads/main/install_tools.sh
+curl -Ls --fail --retry 5 --retry-delay 5 --retry-all-errors -o install_tools.sh https://raw.githubusercontent.com/canonical/certification-lab-ci-tools/refs/heads/main/install_tools.sh
 source install_tools.sh $TOOLS_PATH
 ```
 


### PR DESCRIPTION
Downloading install_tools.sh is sometimes rate-limited by Github.

Recently one of the OEM pipelines has been experiencing failures due to Github’s rate limit when directly downloading scripts.
This has been mitigated by adding retry and fast-fail flags to curl, as in https://github.com/canonical/oemqa-testing-ci/pull/79

Hanhsuan asked me to create the PR here too to help the next user.